### PR TITLE
Fixes to_contiguous_buffer bug

### DIFF
--- a/src/tensorwrapper/tensor/conversions.cpp
+++ b/src/tensorwrapper/tensor/conversions.cpp
@@ -15,11 +15,15 @@ void to_contiguous_buffer(const ScalarTensorWrapper& t, double* buffer_begin,
     auto t_ta = t.get<TA::TSpArrayD>();
     t_ta.make_replicated();
 
+    // Have to use this range to compute ordinal index, using i_range will give
+    // us the offset from the tile start
+    auto erange = t_ta.elements_range();
+
     // XXX: This prohibits vectorization, should be looked into
     for(const auto& tile_i : t_ta) {
         const auto& i_range = tile_i.get().range();
         for(auto idx : i_range)
-            buffer_begin[i_range.ordinal(idx)] = tile_i.get()[idx];
+            buffer_begin[erange.ordinal(idx)] = tile_i.get()[idx];
     }
 }
 

--- a/tests/tensor/conversions.cpp
+++ b/tests/tensor/conversions.cpp
@@ -24,4 +24,16 @@ TEST_CASE("to_vector") {
         std::vector<double> corr{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0};
         REQUIRE(to_vector(t) == corr);
     }
+
+    // The conversion previously had a bug that incorrectly computed the
+    // flattened offset when the tensor had more than one tile. This test
+    // ensures that bug doesn't come back
+    SECTION("More than one tile") {
+        using field_t          = field::Scalar;
+        using single_element_t = SingleElementTiles<field_t>;
+        auto palloc            = std::make_unique<single_element_t>();
+        tensor_type t(tensors.at("matrix"), std::move(palloc));
+        std::vector<double> corr{1.0, 2.0, 3.0, 4.0};
+        REQUIRE(to_vector(t) == corr);
+    }
 }


### PR DESCRIPTION
Prior to this PR, `to_contiguous_buffer` had a bug where ordinal indices were computed relative to the origin of the tile not the entire tensor. So for a two-by-two matrix with single element tiles, the ordinal index of say element 1,0 is computed to be 0 instead of 2. This PR fixes that bug. It's r2g.