### PR TITLE
Update to RuntimeView

### DIFF
--- a/include/tensorwrapper/tensor/allocator/allocator_class.hpp
+++ b/include/tensorwrapper/tensor/allocator/allocator_class.hpp
@@ -4,7 +4,7 @@
 #include "tensorwrapper/tensor/shapes/shapes.hpp"
 #include "tensorwrapper/tensor/type_traits/nd_initializer_list_traits.hpp"
 #include <memory>
-#include <parallelzone/runtime.hpp>
+#include <parallelzone/runtime/runtime_view.hpp>
 #include <vector>
 
 namespace tensorwrapper::tensor::allocator {
@@ -121,7 +121,7 @@ public:
     using allocator_ptr = std::unique_ptr<my_type>;
 
     /// Type of the object describing the runtime
-    using runtime_type = parallelzone::Runtime;
+    using runtime_type = parallelzone::runtime::RuntimeView;
 
     /// A read-write reference to the runtime object
     using runtime_reference = runtime_type&;

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,10 +1,10 @@
 #define CATCH_CONFIG_RUNNER
 #define CATCH_CONFIG_ENABLE_BENCHMARKING
 #include <catch2/catch.hpp>
-#include <parallelzone/runtime.hpp>
+#include <parallelzone/runtime/runtime_view.hpp>
 
 int main(int argc, char* argv[]) {
-    auto rt = parallelzone::Runtime(argc, argv);
+    auto rt = parallelzone::runtime::RuntimeView(argc, argv);
 
     int res = Catch::Session().run(argc, argv);
 


### PR DESCRIPTION
Changes the `runtime_type` to the new `RuntimeView`. This is just spot fixing due to API break. The actual application/usage of the runtime should be looked at again once ParallelZone is matured.