### PR TITLE
Layout and Buffer Update

### DIFF
--- a/include/tensorwrapper/backends/eigen.hpp
+++ b/include/tensorwrapper/backends/eigen.hpp
@@ -25,12 +25,12 @@ namespace tensorwrapper::eigen {
 #ifdef TENSORWRAPPER_HAS_EIGEN
 
 template<typename FloatType, unsigned short Rank>
-using tensor = Eigen::Tensor<FloatType, int(Rank)>;
+using data_type = Eigen::Tensor<FloatType, int(Rank)>;
 
 #else
 
 template<typename, unsigned short>
-using tensor = std::nullptr_t;
+using data_type = std::nullptr_t;
 
 #endif
 

--- a/include/tensorwrapper/buffer/eigen.hpp
+++ b/include/tensorwrapper/buffer/eigen.hpp
@@ -17,7 +17,6 @@
 #pragma once
 #include <tensorwrapper/backends/eigen.hpp>
 #include <tensorwrapper/buffer/replicated.hpp>
-#include <variant>
 
 namespace tensorwrapper::buffer {
 

--- a/include/tensorwrapper/buffer/eigen.hpp
+++ b/include/tensorwrapper/buffer/eigen.hpp
@@ -43,13 +43,13 @@ public:
     using typename my_base_type::const_layout_reference;
 
     /// Type of a rank @p Rank tensor using floats of type @p FloatType
-    using tensor_type = eigen::tensor<FloatType, Rank>;
+    using data_type = eigen::data_type<FloatType, Rank>;
 
-    /// Mutable reference to an object of type tensor_type
-    using tensor_reference = tensor_type&;
+    /// Mutable reference to an object of type data_type
+    using data_reference = data_type&;
 
-    /// Read-only reference to an object of type tensor_type
-    using const_tensor_reference = const tensor_type&;
+    /// Read-only reference to an object of type data_type
+    using const_data_reference = const data_type&;
 
     /** @brief Creates a buffer with no layout and a default initialized
      *         tensor.
@@ -60,8 +60,8 @@ public:
 
     /** @brief Wraps the provided tensor.
      *
-     *  @tparam TensorType The type of the input tensor. Must be implicitly
-     *                     convertible to an object of type tensor_type.
+     *  @tparam DataType The type of the input tensor. Must be implicitly
+     *                     convertible to an object of type data_type.
      *
      *  @param[in] t The tensor to wrap.
      *  @param[in] layout The physical layout of @p t.
@@ -69,9 +69,9 @@ public:
      *  @throw std::bad_alloc if there is a problem copying @p layout. Strong
      *                        throw guarantee.
      */
-    template<typename TensorType>
-    Eigen(TensorType&& t, const_layout_reference layout) :
-      Replicated(layout), m_tensor_(std::forward<TensorType>(t)) {}
+    template<typename DataType>
+    Eigen(DataType&& t, const_layout_reference layout) :
+      Replicated(layout), m_tensor_(std::forward<DataType>(t)) {}
 
     /** @brief Initializes *this with a copy of @p other.
      *
@@ -153,7 +153,7 @@ public:
      */
     bool operator==(const Eigen& rhs) const noexcept {
         if(my_base_type::operator!=(rhs)) return false;
-        eigen::tensor<FloatType, 0> r = (m_tensor_ - rhs.m_tensor_).sum();
+        eigen::data_type<FloatType, 0> r = (m_tensor_ - rhs.m_tensor_).sum();
         return r() == 0.0;
     }
 
@@ -183,7 +183,7 @@ protected:
 
 private:
     /// The actual Eigen tensor
-    tensor_type m_tensor_;
+    data_type m_tensor_;
 };
 
 } // namespace tensorwrapper::buffer

--- a/include/tensorwrapper/layout/layout_base.hpp
+++ b/include/tensorwrapper/layout/layout_base.hpp
@@ -90,6 +90,20 @@ public:
       LayoutBase(shape.clone(), std::make_unique<symmetry_type>(symmetry),
                  std::make_unique<sparsity_type>(sparsity)) {}
 
+    /** @brief Initialize by shape copy ctor
+     *
+     *  This ctor is to create an instance with the provided shape and no
+     *  symmetry or sparsity. Will copy the shape.
+     *
+     *  @param[in] shape The actual shape the tensor backend has.
+     *
+     *  @throw std::bad_alloc if there is a problem allocating the new state.
+     *                        Strong throw guarantee.
+     */
+    LayoutBase(const_shape_reference shape) :
+      LayoutBase(shape.clone(), std::make_unique<symmetry_type>(),
+                 std::make_unique<sparsity_type>()) {}
+
     /** @brief Initialize by move ctor
      *
      *  This ctor is used when the user wants *this to take ownership of the
@@ -108,6 +122,25 @@ public:
             throw std::runtime_error("Symmetry can't be null");
         if(m_sparsity_ == nullptr)
             throw std::runtime_error("Sparsity can't be null");
+    }
+
+    /** @brief Initialize by shape move ctor
+     *
+     *  This ctor is to create an instance with the provided shape and no
+     *  symmetry or sparsity. Will move the shape, and default the symmetry
+     *  and sparsity.
+     *
+     *  @param[in] shape The actual shape the tensor backend has.
+     *
+     *  @throw std::bad_alloc if there is a problem allocating the new state.
+     *                        Strong throw guarantee.
+     *  @throw std::runtime_error if @p shape, is a nullptr. Strong throw
+     *                            guarantee.
+     */
+    LayoutBase(shape_pointer shape) : m_shape_(std::move(shape)) {
+        if(m_shape_ == nullptr) throw std::runtime_error("Shape can't be null");
+        m_symmetry_ = std::make_unique<symmetry_type>();
+        m_sparsity_ = std::make_unique<sparsity_type>();
     }
 
     /// Defaulted polymorphic dtor
@@ -194,7 +227,7 @@ protected:
       m_sparsity_(std::make_unique<sparsity_type>(*other.m_sparsity_)) {}
 
     LayoutBase& operator=(const LayoutBase&) = delete;
-    LayoutBase& operator=(LayoutBase&&) = delete;
+    LayoutBase& operator=(LayoutBase&&)      = delete;
 
 private:
     /// The actual shape of the tensor

--- a/include/tensorwrapper/layout/layout_base.hpp
+++ b/include/tensorwrapper/layout/layout_base.hpp
@@ -227,7 +227,7 @@ protected:
       m_sparsity_(std::make_unique<sparsity_type>(*other.m_sparsity_)) {}
 
     LayoutBase& operator=(const LayoutBase&) = delete;
-    LayoutBase& operator=(LayoutBase&&)      = delete;
+    LayoutBase& operator=(LayoutBase&&) = delete;
 
 private:
     /// The actual shape of the tensor

--- a/include/tensorwrapper/layout/logical.hpp
+++ b/include/tensorwrapper/layout/logical.hpp
@@ -44,10 +44,14 @@ public:
             const_sparsity_reference sparsity) :
       my_base_type(shape, symmetry, sparsity) {}
 
+    Logical(const_shape_reference shape) : my_base_type(shape) {}
+
     Logical(shape_pointer pshape, symmetry_pointer psymmetry,
             sparsity_pointer psparsity) :
       my_base_type(std::move(pshape), std::move(psymmetry),
                    std::move(psparsity)) {}
+
+    Logical(shape_pointer pshape) : my_base_type(std::move(pshape)) {}
 
 protected:
     /// Implements clone by calling copy ctor

--- a/include/tensorwrapper/layout/physical.hpp
+++ b/include/tensorwrapper/layout/physical.hpp
@@ -43,10 +43,14 @@ public:
              const_sparsity_reference sparsity) :
       my_base_type(shape, symmetry, sparsity) {}
 
+    Physical(const_shape_reference shape) : my_base_type(shape) {}
+
     Physical(shape_pointer pshape, symmetry_pointer psymmetry,
              sparsity_pointer psparsity) :
       my_base_type(std::move(pshape), std::move(psymmetry),
                    std::move(psparsity)) {}
+
+    Physical(shape_pointer pshape) : my_base_type(std::move(pshape)) {}
 
 protected:
     /// Implements clone by calling copy ctor

--- a/src/tensorwrapper/allocator/eigen.cpp
+++ b/src/tensorwrapper/allocator/eigen.cpp
@@ -35,12 +35,12 @@ auto unwrap_shape(const ShapeType& shape, std::index_sequence<Is...>) {
 TPARAMS
 typename EIGEN::eigen_buffer_pointer EIGEN::allocate(
   eigen_layout_pointer playout) {
-    using eigen_tensor_type = typename eigen_buffer_type::tensor_type;
+    using eigen_data_type = typename eigen_buffer_type::data_type;
     if(playout->shape().rank() != Rank)
         throw std::runtime_error("Rank of the layout is not compatible");
 
     return std::make_unique<eigen_buffer_type>(
-      unwrap_shape<eigen_tensor_type>(playout->shape(),
+      unwrap_shape<eigen_data_type>(playout->shape(),
                                       std::make_index_sequence<Rank>()),
       *playout);
 }

--- a/src/tensorwrapper/allocator/eigen.cpp
+++ b/src/tensorwrapper/allocator/eigen.cpp
@@ -41,7 +41,7 @@ typename EIGEN::eigen_buffer_pointer EIGEN::allocate(
 
     return std::make_unique<eigen_buffer_type>(
       unwrap_shape<eigen_data_type>(playout->shape(),
-                                      std::make_index_sequence<Rank>()),
+                                    std::make_index_sequence<Rank>()),
       *playout);
 }
 

--- a/tests/cxx/unit_tests/tensorwrapper/allocator/eigen.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/allocator/eigen.cpp
@@ -32,9 +32,9 @@ TEMPLATE_TEST_CASE("EigenAllocator", "", float, double) {
     using eigen_buffer_scalar = typename scalar_alloc_type::eigen_buffer_type;
     using eigen_buffer_vector = typename vector_alloc_type::eigen_buffer_type;
     using eigen_buffer_matrix = typename matrix_alloc_type::eigen_buffer_type;
-    using eigen_scalar        = typename eigen_buffer_scalar::tensor_type;
-    using eigen_vector        = typename eigen_buffer_vector::tensor_type;
-    using eigen_matrix        = typename eigen_buffer_matrix::tensor_type;
+    using eigen_scalar        = typename eigen_buffer_scalar::data_type;
+    using eigen_vector        = typename eigen_buffer_vector::data_type;
+    using eigen_matrix        = typename eigen_buffer_matrix::data_type;
 
     parallelzone::runtime::RuntimeView rv;
 

--- a/tests/cxx/unit_tests/tensorwrapper/buffer/buffer_base.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/buffer/buffer_base.cpp
@@ -35,10 +35,10 @@ TEST_CASE("BufferBase") {
         using scalar_buffer = buffer::Eigen<float, 0>;
         using vector_buffer = buffer::Eigen<float, 1>;
 
-        typename scalar_buffer::tensor_type eigen_scalar;
+        typename scalar_buffer::data_type eigen_scalar;
         eigen_scalar() = 1.0;
 
-        typename vector_buffer::tensor_type eigen_vector(2);
+        typename vector_buffer::data_type eigen_vector(2);
         eigen_vector(0) = 1.0;
         eigen_vector(1) = 2.0;
 

--- a/tests/cxx/unit_tests/tensorwrapper/buffer/eigen.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/buffer/eigen.cpp
@@ -40,14 +40,14 @@ TEMPLATE_TEST_CASE("Eigen", "", float, double) {
         using vector_buffer = buffer::Eigen<TestType, 1>;
         using matrix_buffer = buffer::Eigen<TestType, 2>;
 
-        typename scalar_buffer::tensor_type eigen_scalar;
+        typename scalar_buffer::data_type eigen_scalar;
         eigen_scalar() = 1.0;
 
-        typename vector_buffer::tensor_type eigen_vector(2);
+        typename vector_buffer::data_type eigen_vector(2);
         eigen_vector(0) = 1.0;
         eigen_vector(1) = 2.0;
 
-        typename matrix_buffer::tensor_type eigen_matrix(2, 3);
+        typename matrix_buffer::data_type eigen_matrix(2, 3);
         eigen_matrix(0, 0) = 1.0;
         eigen_matrix(0, 1) = 2.0;
         eigen_matrix(0, 2) = 3.0;
@@ -101,7 +101,7 @@ TEMPLATE_TEST_CASE("Eigen", "", float, double) {
             // different everything, same tensor different layout, and different
             // tensor same layout.
 
-            typename scalar_buffer::tensor_type eigen_scalar2;
+            typename scalar_buffer::data_type eigen_scalar2;
             eigen_scalar2() = 1.0;
 
             // Everything the same
@@ -128,7 +128,7 @@ TEMPLATE_TEST_CASE("Eigen", "", float, double) {
         SECTION("operator!=") {
             // This just negates operator== so spot-checking is okay
 
-            typename scalar_buffer::tensor_type eigen_scalar2;
+            typename scalar_buffer::data_type eigen_scalar2;
             eigen_scalar2() = 1.0;
 
             // Everything the same

--- a/tests/cxx/unit_tests/tensorwrapper/inputs.hpp
+++ b/tests/cxx/unit_tests/tensorwrapper/inputs.hpp
@@ -27,7 +27,7 @@ inline auto default_input() { return detail_::TensorInput{}; }
 
 inline auto smooth_scalar() {
     using buffer_type = buffer::Eigen<double, 0>;
-    using data_type = typename buffer_type::data_type;
+    using data_type   = typename buffer_type::data_type;
     shape::Smooth shape{};
     layout::Physical l(shape);
     data_type scalar;
@@ -38,7 +38,7 @@ inline auto smooth_scalar() {
 /// 5 element vector such that element i is i
 inline auto smooth_vector() {
     using buffer_type = buffer::Eigen<double, 1>;
-    using data_type = typename buffer_type::data_type;
+    using data_type   = typename buffer_type::data_type;
     shape::Smooth shape{5};
     layout::Physical l(shape);
     data_type vector(5);
@@ -49,7 +49,7 @@ inline auto smooth_vector() {
 /// 5 element vector internally stored as a 5 by 1 matrix
 inline auto smooth_vector_alt() {
     using buffer_type = buffer::Eigen<double, 2>;
-    using data_type = typename buffer_type::data_type;
+    using data_type   = typename buffer_type::data_type;
     shape::Smooth shape{5};
     layout::Physical l(shape::Smooth{5, 1});
     data_type matrix(5, 1);

--- a/tests/cxx/unit_tests/tensorwrapper/inputs.hpp
+++ b/tests/cxx/unit_tests/tensorwrapper/inputs.hpp
@@ -27,10 +27,10 @@ inline auto default_input() { return detail_::TensorInput{}; }
 
 inline auto smooth_scalar() {
     using buffer_type = buffer::Eigen<double, 0>;
-    using tensor_type = typename buffer_type::tensor_type;
+    using data_type = typename buffer_type::data_type;
     shape::Smooth shape{};
     layout::Physical l(shape);
-    tensor_type scalar;
+    data_type scalar;
     scalar() = 42.0;
     return detail_::TensorInput(shape, buffer_type(scalar, l));
 }
@@ -38,10 +38,10 @@ inline auto smooth_scalar() {
 /// 5 element vector such that element i is i
 inline auto smooth_vector() {
     using buffer_type = buffer::Eigen<double, 1>;
-    using tensor_type = typename buffer_type::tensor_type;
+    using data_type = typename buffer_type::data_type;
     shape::Smooth shape{5};
     layout::Physical l(shape);
-    tensor_type vector(5);
+    data_type vector(5);
     for(std::size_t i = 0; i < 5; ++i) vector(i) = i;
     return detail_::TensorInput(shape, buffer_type(vector, l));
 }
@@ -49,10 +49,10 @@ inline auto smooth_vector() {
 /// 5 element vector internally stored as a 5 by 1 matrix
 inline auto smooth_vector_alt() {
     using buffer_type = buffer::Eigen<double, 2>;
-    using tensor_type = typename buffer_type::tensor_type;
+    using data_type = typename buffer_type::data_type;
     shape::Smooth shape{5};
     layout::Physical l(shape::Smooth{5, 1});
-    tensor_type matrix(5, 1);
+    data_type matrix(5, 1);
     for(std::size_t i = 0; i < 5; ++i) matrix(i, 0) = i;
     return detail_::TensorInput(shape, buffer_type(matrix, l));
 }

--- a/tests/cxx/unit_tests/tensorwrapper/inputs.hpp
+++ b/tests/cxx/unit_tests/tensorwrapper/inputs.hpp
@@ -26,40 +26,34 @@ namespace tensorwrapper::testing {
 inline auto default_input() { return detail_::TensorInput{}; }
 
 inline auto smooth_scalar() {
-    shape::Smooth shape{};
     using buffer_type = buffer::Eigen<double, 0>;
     using tensor_type = typename buffer_type::tensor_type;
+    shape::Smooth shape{};
+    layout::Physical l(shape);
     tensor_type scalar;
     scalar() = 42.0;
-    layout::Physical l(shape, symmetry::Group{}, sparsity::Pattern{});
     return detail_::TensorInput(shape, buffer_type(scalar, l));
 }
 
 /// 5 element vector such that element i is i
 inline auto smooth_vector() {
-    shape::Smooth shape{5};
     using buffer_type = buffer::Eigen<double, 1>;
     using tensor_type = typename buffer_type::tensor_type;
+    shape::Smooth shape{5};
+    layout::Physical l(shape);
     tensor_type vector(5);
     for(std::size_t i = 0; i < 5; ++i) vector(i) = i;
-
-    symmetry::Group g;
-    sparsity::Pattern p;
-    layout::Physical l(shape, g, p);
     return detail_::TensorInput(shape, buffer_type(vector, l));
 }
 
 /// 5 element vector internally stored as a 5 by 1 matrix
 inline auto smooth_vector_alt() {
-    shape::Smooth shape{5};
     using buffer_type = buffer::Eigen<double, 2>;
     using tensor_type = typename buffer_type::tensor_type;
+    shape::Smooth shape{5};
+    layout::Physical l(shape::Smooth{5, 1});
     tensor_type matrix(5, 1);
     for(std::size_t i = 0; i < 5; ++i) matrix(i, 0) = i;
-
-    symmetry::Group g;
-    sparsity::Pattern p;
-    layout::Physical l(shape::Smooth{5, 1}, g, p);
     return detail_::TensorInput(shape, buffer_type(matrix, l));
 }
 

--- a/tests/cxx/unit_tests/tensorwrapper/layout/logical.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/layout/logical.cpp
@@ -36,33 +36,41 @@ TEST_CASE("Logical") {
     symmetry::Group no_symm, symm{p01};
     sparsity::Pattern no_sparsity;
 
-    Logical matrix(matrix_shape, no_symm, no_sparsity);
-    Logical symm_matrix(matrix_shape, symm, no_sparsity);
+    Logical logi_copy_no_sym(matrix_shape, no_symm, no_sparsity);
+    Logical logi_copy_has_sym(matrix_shape, symm, no_sparsity);
+    Logical logi_copy_just_shape(matrix_shape);
 
     SECTION("Ctors and assignment") {
         SECTION("Value") {
-            REQUIRE(matrix.symmetry() == no_symm);
-            REQUIRE(matrix.sparsity() == no_sparsity);
+            REQUIRE(logi_copy_no_sym.symmetry() == no_symm);
+            REQUIRE(logi_copy_no_sym.sparsity() == no_sparsity);
 
-            REQUIRE(symm_matrix.symmetry() == symm);
-            REQUIRE(symm_matrix.sparsity() == no_sparsity);
+            REQUIRE(logi_copy_has_sym.symmetry() == symm);
+            REQUIRE(logi_copy_has_sym.sparsity() == no_sparsity);
+
+            REQUIRE(logi_copy_just_shape.symmetry() == no_symm);
+            REQUIRE(logi_copy_just_shape.sparsity() == no_sparsity);
         }
     }
 
     SECTION("Virtual method overrides") {
         using const_base_reference = Logical::const_layout_reference;
 
-        const_base_reference matrix_base      = matrix;
-        const_base_reference symm_matrix_base = symm_matrix;
+        const_base_reference base_copy_no_sym     = logi_copy_no_sym;
+        const_base_reference base_copy_has_sym    = logi_copy_has_sym;
+        const_base_reference base_copy_just_shape = logi_copy_just_shape;
 
         SECTION("clone_") {
-            REQUIRE(matrix_base.clone()->are_equal(matrix));
-            REQUIRE(symm_matrix_base.clone()->are_equal(symm_matrix));
+            REQUIRE(base_copy_no_sym.clone()->are_equal(logi_copy_no_sym));
+            REQUIRE(base_copy_has_sym.clone()->are_equal(logi_copy_has_sym));
+            REQUIRE(
+              base_copy_just_shape.clone()->are_equal(logi_copy_just_shape));
         }
 
         SECTION("are_equal") {
-            REQUIRE(matrix_base.are_equal(matrix_base));
-            REQUIRE_FALSE(symm_matrix_base.are_equal(matrix_base));
+            REQUIRE(base_copy_no_sym.are_equal(base_copy_no_sym));
+            REQUIRE_FALSE(base_copy_has_sym.are_equal(base_copy_no_sym));
+            REQUIRE(base_copy_just_shape.are_equal(base_copy_no_sym));
         }
     }
 }

--- a/tests/cxx/unit_tests/tensorwrapper/layout/physical.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/layout/physical.cpp
@@ -36,33 +36,41 @@ TEST_CASE("Physical") {
     symmetry::Group no_symm, symm{p01};
     sparsity::Pattern no_sparsity;
 
-    Physical matrix(matrix_shape, no_symm, no_sparsity);
-    Physical symm_matrix(matrix_shape, symm, no_sparsity);
+    Physical phys_copy_no_sym(matrix_shape, no_symm, no_sparsity);
+    Physical phys_copy_has_sym(matrix_shape, symm, no_sparsity);
+    Physical phys_copy_just_shape(matrix_shape);
 
     SECTION("Ctors and assignment") {
         SECTION("Value") {
-            REQUIRE(matrix.symmetry() == no_symm);
-            REQUIRE(matrix.sparsity() == no_sparsity);
+            REQUIRE(phys_copy_no_sym.symmetry() == no_symm);
+            REQUIRE(phys_copy_no_sym.sparsity() == no_sparsity);
 
-            REQUIRE(symm_matrix.symmetry() == symm);
-            REQUIRE(symm_matrix.sparsity() == no_sparsity);
+            REQUIRE(phys_copy_has_sym.symmetry() == symm);
+            REQUIRE(phys_copy_has_sym.sparsity() == no_sparsity);
+
+            REQUIRE(phys_copy_just_shape.symmetry() == no_symm);
+            REQUIRE(phys_copy_just_shape.sparsity() == no_sparsity);
         }
     }
 
     SECTION("Virtual method overrides") {
         using const_base_reference = Physical::const_layout_reference;
 
-        const_base_reference matrix_base      = matrix;
-        const_base_reference symm_matrix_base = symm_matrix;
+        const_base_reference base_copy_no_sym     = phys_copy_no_sym;
+        const_base_reference base_copy_has_sym    = phys_copy_has_sym;
+        const_base_reference base_copy_just_shape = phys_copy_just_shape;
 
         SECTION("clone_") {
-            REQUIRE(matrix_base.clone()->are_equal(matrix));
-            REQUIRE(symm_matrix_base.clone()->are_equal(symm_matrix));
+            REQUIRE(base_copy_no_sym.clone()->are_equal(phys_copy_no_sym));
+            REQUIRE(base_copy_has_sym.clone()->are_equal(phys_copy_has_sym));
+            REQUIRE(
+              base_copy_just_shape.clone()->are_equal(phys_copy_just_shape));
         }
 
         SECTION("are_equal") {
-            REQUIRE(matrix_base.are_equal(matrix_base));
-            REQUIRE_FALSE(symm_matrix_base.are_equal(matrix_base));
+            REQUIRE(base_copy_no_sym.are_equal(base_copy_no_sym));
+            REQUIRE_FALSE(base_copy_has_sym.are_equal(base_copy_no_sym));
+            REQUIRE(base_copy_just_shape.are_equal(base_copy_no_sym));
         }
     }
 }

--- a/tests/cxx/unit_tests/tensorwrapper/tensor/detail_/tensor_pimpl.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/tensor/detail_/tensor_pimpl.cpp
@@ -23,7 +23,6 @@
 
 using namespace tensorwrapper;
 using buffer_type = buffer::Eigen<double, 2>;
-using tensor_type = typename buffer_type::tensor_type;
 
 TEST_CASE("TensorPIMPL") {
     auto input = testing::smooth_vector();


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
Adds ctors to the Layouts that only take a shape, allowing for less verbose construction when there is no symmetry or sparsity. Renames variables in the Layout tests in an attempt to be more descriptive.

Also changes the typename of  `tensorwrapper::eigen::tensor` (and related types) to `tensorwrapper::eigen::data_type`, to avoid potential confusion around what "tensor" means in a given location. In general, "tensor" should refer to the primary class `tensorwrapper::Tensor`, while tensor-like data structures of a backend should be referred to as "data" (or something synonymous).