### PR TITLE
Adds Basic Math

### DIFF
--- a/include/tensorwrapper/dsl/dsl.hpp
+++ b/include/tensorwrapper/dsl/dsl.hpp
@@ -1,0 +1,2 @@
+#pragma once
+#include <tensorwrapper/dsl/labeled.hpp>

--- a/include/tensorwrapper/dsl/dsl_forward.hpp
+++ b/include/tensorwrapper/dsl/dsl_forward.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace tensorwrapper::dsl {
+
+template<typename ObjectType, typename LabelType>
+class Labeled;
+
+template<typename ObjectType, typename LabelType>
+class Parser;
+
+} // namespace tensorwrapper::dsl

--- a/include/tensorwrapper/dsl/labeled.hpp
+++ b/include/tensorwrapper/dsl/labeled.hpp
@@ -1,0 +1,52 @@
+#pragma once
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <iostream>
+#include <tensorwrapper/dsl/parser.hpp>
+#include <type_traits>
+#include <utilities/dsl/dsl.hpp>
+namespace tensorwrapper::dsl {
+
+/** @brief Represents an object whose modes are assigned dummy indices.
+ */
+template<typename ObjectType, typename LabelType = std::string>
+class Labeled : public utilities::dsl::BinaryOp<Labeled<ObjectType, LabelType>,
+                                                ObjectType, LabelType> {
+private:
+    /// Type of *this
+    using my_type = Labeled<ObjectType, LabelType>;
+
+    /// Type *this inherits from
+    using op_type = utilities::dsl::BinaryOp<my_type, ObjectType, LabelType>;
+
+public:
+    /// Reuse the base class's ctor
+    using op_type::op_type;
+
+    template<typename TermType>
+    my_type& operator=(TermType&& other) {
+        Parser<ObjectType, LabelType> p;
+        *this = p.dispatch(std::move(*this), std::forward<TermType>(other));
+        return *this;
+    }
+
+    decltype(auto) labels() { return rhs(); }
+    decltype(auto) labels() const { return rhs(); }
+};
+
+} // namespace tensorwrapper::dsl

--- a/include/tensorwrapper/dsl/parser.hpp
+++ b/include/tensorwrapper/dsl/parser.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include <tensorwrapper/dsl/dsl_forward.hpp>
+#include <utilities/dsl/dsl.hpp>
+
+namespace tensorwrapper::dsl {
+
+/** @brief Object which walks the AST of an expression.
+ *
+ */
+template<typename ObjectType, typename LabelType>
+class Parser {
+public:
+    /// Type of a leaf in the AST
+    using labeled_type = Labeled<ObjectType, LabelType>;
+
+    /** @brief Recursion end-point
+     *
+     *
+     */
+    auto dispatch(labeled_type lhs, labeled_type rhs) {
+        return assign(std::move(lhs), std::move(rhs));
+    }
+
+    template<typename T, typename U>
+    auto dispatch(labeled_type lhs, const utilities::dsl::Add<T, U>& rhs) {
+        auto lA = dispatch(lhs, rhs.lhs());
+        auto lB = dispatch(lhs, rhs.rhs());
+        return add(std::move(lhs), std::move(lA), std::move(lB));
+    }
+
+protected:
+    labeled_type assign(labeled_type lhs, labeled_type rhs);
+    labeled_type add(labeled_type result, labeled_type lhs, labeled_type rhs);
+};
+
+extern template class Parser<Tensor, std::string>;
+
+} // namespace tensorwrapper::dsl

--- a/include/tensorwrapper/tensor/tensor_class.hpp
+++ b/include/tensorwrapper/tensor/tensor_class.hpp
@@ -15,6 +15,7 @@
  */
 
 #pragma once
+#include <tensorwrapper/dsl/labeled.hpp>
 #include <tensorwrapper/tensor/detail_/tensor_input.hpp>
 
 namespace tensorwrapper {
@@ -71,6 +72,18 @@ public:
 
     /// Type of an initializer list if *this is a rank 4 tensor
     using tensor4_il_type = std::initializer_list<tensor3_il_type>;
+
+    /// Type of a label
+    using label_type = std::string;
+
+    /// Type of a read-only reference to an object of type label_type
+    using const_label_reference = const label_type&;
+
+    /// Type of a labeled tensor
+    using labeled_tensor_type = dsl::Labeled<Tensor, label_type>;
+
+    /// Type of a read-only labeled tensor
+    using const_labeled_tensor_type = dsl::Labeled<const Tensor, label_type>;
 
     /** @brief Initializes *this by processing the input provided in @p input.
      *
@@ -259,6 +272,14 @@ public:
      *                            guarantee.
      */
     const_buffer_reference buffer() const;
+
+    labeled_tensor_type operator()(const_label_reference labels) {
+        return labeled_tensor_type(*this, labels);
+    }
+
+    const_labeled_tensor_type operator()(const_label_reference labels) const {
+        return const_labeled_tensor_type(*this, labels);
+    }
 
     // -------------------------------------------------------------------------
     // -- Utility methods

--- a/include/tensorwrapper/tensorwrapper.hpp
+++ b/include/tensorwrapper/tensorwrapper.hpp
@@ -19,6 +19,7 @@
 #include <tensorwrapper/backends/backends.hpp>
 #include <tensorwrapper/buffer/buffer.hpp>
 #include <tensorwrapper/detail_/detail_.hpp>
+#include <tensorwrapper/dsl/dsl.hpp>
 #include <tensorwrapper/layout/layout.hpp>
 #include <tensorwrapper/shape/shape.hpp>
 #include <tensorwrapper/sparsity/sparsity.hpp>

--- a/src/tensorwrapper/dsl/executor/eigen.hpp
+++ b/src/tensorwrapper/dsl/executor/eigen.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <tensorwrapper/tensor/tensor_class.hpp>
+namespace tensorwrapper::dsl::executor {
+
+/** @brief Converts tensors to Eigen::tensor then executes the operation.
+ *
+ *
+ */
+class Eigen {
+public:
+    using labeled_tensor = typename Tensor::labeled_tensor;
+
+    static labeled_tensor assign(labeled_tensor lhs, labeled_tensor rhs) {
+        if(lhs.labels() != rhs.labels()) { // Transpose needed
+        }
+    }
+
+    static labeled_tensor add(labeled_tensor result, labeled_tensor lhs,
+                              labeled_tensor rhs) {}
+};
+
+} // namespace tensorwrapper::dsl::executor

--- a/src/tensorwrapper/dsl/executor/executor.hpp
+++ b/src/tensorwrapper/dsl/executor/executor.hpp
@@ -1,0 +1,2 @@
+#pragma once
+#include "eigen.hpp"

--- a/src/tensorwrapper/dsl/parser.cpp
+++ b/src/tensorwrapper/dsl/parser.cpp
@@ -1,0 +1,40 @@
+#include "executor/executor.hpp"
+#include <tensorwrapper/dsl/parser.hpp>
+
+namespace tensorwrapper::dsl {
+
+// Specialize this class to set the class based on the objects being combined
+template<typename ObjectType>
+struct ExecutorType;
+
+// Sets the default executor for tensors
+template<>
+struct ExecutorType<Tensor> {
+    using executor_type = executor::Eigen;
+};
+
+// Typedef to shorten retrieving the type of default executor for @p ObjectType
+template<typename ObjectType>
+using default_executor_type = typename ExecutorType<ObjectType>::executor_type;
+
+#define TPARAMS template<typename ObjectType, typename LabelType>
+#define PARSER Parser<ObjectType, LabelType>
+#define LABELED_TYPE typename PARSER::labeled_type
+
+TPARAMS LABELED_TYPE PARSER::assign(labeled_type lhs, labeled_type rhs) {
+    return default_executor_type<ObjectType>::assign(std::move(lhs),
+                                                     std::move(rhs));
+}
+
+TPARAMS LABELED_TYPE PARSER::add(labeled_type result, labeled_type lhs,
+                                 labeled_type rhs) {
+    return default_executor_type<ObjectType>::add(
+      std::move(result), std::move(lhs), std::move(rhs));
+}
+
+#undef PARSER
+#undef TPARAMS
+
+template class Parser<Tensor, std::string>;
+
+} // namespace tensorwrapper::dsl

--- a/tests/cxx/unit_tests/tensorwrapper/tensor/tensor_class.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/tensor/tensor_class.cpp
@@ -111,6 +111,27 @@ TEST_CASE("Tensor") {
         REQUIRE_THROWS_AS(const_defaulted.buffer(), std::runtime_error);
     }
 
+    SECTION("operator(std::string)") {
+        auto labeled_scalar = scalar("");
+        auto labeled_vector = vector("i");
+
+        using labeled_tensor_type = Tensor::labeled_tensor_type;
+        REQUIRE(labeled_scalar == labeled_tensor_type(scalar, ""));
+        REQUIRE(labeled_vector == labeled_tensor_type(vector, "i"));
+
+        Tensor B;
+        B("j") = labeled_scalar;
+    }
+
+    SECTION("operator(std::string) const") {
+        auto labeled_scalar = std::as_const(scalar)("");
+        auto labeled_vector = std::as_const(vector)("i");
+
+        using const_labeled_tensor_type = Tensor::const_labeled_tensor_type;
+        REQUIRE(labeled_scalar == const_labeled_tensor_type(scalar, ""));
+        REQUIRE(labeled_vector == const_labeled_tensor_type(vector, "i"));
+    }
+
     SECTION("swap") {
         Tensor scalar_copy(scalar);
         Tensor vector_copy(vector);


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
This PR adds the Einstein-summation-convention DSL to TensorWrapper and implements it for basic
math operations.

**TODOs**
Finish adding DSL terms to Parser. Implementing the Eigen executor. Tests. Documentation.
