### PR TITLE
DSL Supports Tensor (Finally)

### DIFF
--- a/include/tensorwrapper/buffer/eigen.hpp
+++ b/include/tensorwrapper/buffer/eigen.hpp
@@ -199,6 +199,9 @@ protected:
     dsl_reference permute_assignment_(label_type this_labels,
                                       const_labeled_reference rhs) override;
 
+    dsl_reference scalar_multiplication_(label_type this_labels, double scalar,
+                                         const_labeled_reference rhs) override;
+
     /// Implements to_string
     typename polymorphic_base::string_type to_string_() const override;
 

--- a/include/tensorwrapper/detail_/dsl_base.hpp
+++ b/include/tensorwrapper/detail_/dsl_base.hpp
@@ -209,16 +209,18 @@ public:
      *  @tparam ScalarType The type of @p scalar. Assumed to be a floating-
      *                     point type.
      *
-     *  This method is responsible for scaling @p *this by @p scalar.
+     *  This method is responsible for scaling @p rhs by @p scalar and assigning
+     *  it to *this.
      *
      *  @note This method is templated on the scalar type to avoid limiting the
      *        API. That said, at present the backend converts @p scalar to
-     *        double precision.
+     *        double precision, but we could use a variant or something similar
+     *        to avoid this
      */
-    template<typename ScalarType>
-    dsl_reference scalar_multiplication(ScalarType&& scalar) {
-        return scalar_multiplication_(std::forward<ScalarType>(scalar));
-    }
+    template<typename LabelType, typename ScalarType>
+    dsl_reference scalar_multiplication(LabelType&& this_labels,
+                                        ScalarType&& scalar,
+                                        const_labeled_reference rhs);
 
 protected:
     /// Derived class should overwrite to implement addition_assignment
@@ -249,7 +251,9 @@ protected:
     }
 
     /// Derived class should overwrite to implement scalar_multiplication
-    dsl_reference scalar_multiplication_(double scalar) {
+    virtual dsl_reference scalar_multiplication_(label_type this_labels,
+                                                 double scalar,
+                                                 const_labeled_reference rhs) {
         throw std::runtime_error("Scalar multiplication NYI");
     }
 

--- a/include/tensorwrapper/detail_/dsl_base.ipp
+++ b/include/tensorwrapper/detail_/dsl_base.ipp
@@ -84,6 +84,18 @@ typename DSL_BASE::dsl_reference DSL_BASE::permute_assignment(
     return permute_assignment_(std::move(lhs_labels), rhs);
 }
 
+TPARAMS
+template<typename LabelType, typename FloatType>
+typename DSL_BASE::dsl_reference DSL_BASE::scalar_multiplication(
+  LabelType&& this_labels, FloatType&& scalar, const_labeled_reference rhs) {
+    assert_indices_match_rank_(rhs);
+
+    label_type lhs_labels(std::forward<LabelType>(this_labels));
+    assert_is_subset_(lhs_labels, rhs.labels());
+
+    return scalar_multiplication_(std::move(lhs_labels), scalar, rhs);
+}
+
 #undef DSL_BASE
 #undef TPARAMS
 

--- a/include/tensorwrapper/tensor/tensor_class.hpp
+++ b/include/tensorwrapper/tensor/tensor_class.hpp
@@ -15,7 +15,8 @@
  */
 
 #pragma once
-#include <tensorwrapper/dsl/labeled.hpp>
+#include <tensorwrapper/detail_/dsl_base.hpp>
+#include <tensorwrapper/detail_/polymorphic_base.hpp>
 #include <tensorwrapper/tensor/detail_/tensor_input.hpp>
 
 namespace tensorwrapper {
@@ -34,7 +35,8 @@ struct IsTuple<std::tuple<Args...>> : std::true_type {};
  *  The Tensor class is envisioned as being the most user-facing class of
  *  TensorWrapper and forms the entry point into TensorWrapper's DSL.
  */
-class Tensor {
+class Tensor : public detail_::DSLBase<Tensor>,
+               public detail_::PolymorphicBase<Tensor> {
 private:
     /// Type of a helper class which collects the inputs needed to make a tensor
     using input_type = detail_::TensorInput;
@@ -52,6 +54,8 @@ private:
     template<typename... Args>
     using enable_if_no_tensors_t =
       std::enable_if_t<!are_any_tensors_v<Args...>>;
+
+    using polymorphic_base = detail_::PolymorphicBase<Tensor>;
 
 public:
     /// Type of the object implementing *this
@@ -80,6 +84,9 @@ public:
 
     /// Type of a pointer to a read-only buffer
     using const_buffer_pointer = input_type::const_buffer_pointer;
+
+    /// Type used to convey rank
+    using rank_type = typename logical_layout_type::size_type;
 
     /// Type of an initializer list if *this is a scalar
     using scalar_il_type = double;
@@ -299,6 +306,8 @@ public:
      */
     const_buffer_reference buffer() const;
 
+    rank_type rank() const;
+
     // -------------------------------------------------------------------------
     // -- Utility methods
     // -------------------------------------------------------------------------
@@ -343,6 +352,39 @@ public:
      *  @throw None No throw guarantee.
      */
     bool operator!=(const Tensor& rhs) const noexcept;
+
+protected:
+    /// Implements clone by calling copy ctor
+    polymorphic_base::base_pointer clone_() const override {
+        return std::make_unique<Tensor>(*this);
+    }
+
+    /// Implements are_equal by calling are_equal_impl_
+    bool are_equal_(const_base_reference rhs) const noexcept override {
+        return polymorphic_base::are_equal_impl_<Tensor>(rhs);
+    }
+
+    /// Implements addition_assignment by calling addition_assignment on state
+    dsl_reference addition_assignment_(label_type this_labels,
+                                       const_labeled_reference lhs,
+                                       const_labeled_reference rhs) override;
+
+    /// Calls subtraction_assignment on each member
+    dsl_reference subtraction_assignment_(label_type this_labels,
+                                          const_labeled_reference lhs,
+                                          const_labeled_reference rhs) override;
+
+    /// Calls multiplication_assignment on each member
+    dsl_reference multiplication_assignment_(
+      label_type this_labels, const_labeled_reference lhs,
+      const_labeled_reference rhs) override;
+
+    /// Calls permute_assignment on each member
+    dsl_reference permute_assignment_(label_type this_labels,
+                                      const_labeled_reference rhs) override;
+
+    /// Implements to_string
+    typename polymorphic_base::string_type to_string_() const override;
 
 private:
     /// All ctors ultimately dispatch to this ctor

--- a/include/tensorwrapper/tensor/tensor_class.hpp
+++ b/include/tensorwrapper/tensor/tensor_class.hpp
@@ -306,6 +306,17 @@ public:
      */
     const_buffer_reference buffer() const;
 
+    /** @brief Returns the logical rank of the tensor.
+     *
+     *  Most users interacting with a tensor will be thinking of it in terms of
+     *  its logical rank. This function is a convenience function for calling
+     *  `rank()` on the logical layout.
+     *
+     *  @return The rank of the tensor, logically.
+     *
+     *  @throw std::runtime_error if *this does not have a logical layout.
+     *                            Strong throw guarantee.
+     */
     rank_type rank() const;
 
     // -------------------------------------------------------------------------
@@ -378,6 +389,10 @@ protected:
     dsl_reference multiplication_assignment_(
       label_type this_labels, const_labeled_reference lhs,
       const_labeled_reference rhs) override;
+
+    /// Calls scalar_multiplication on each member
+    dsl_reference scalar_multiplication_(label_type this_labels, double scalar,
+                                         const_labeled_reference rhs) override;
 
     /// Calls permute_assignment on each member
     dsl_reference permute_assignment_(label_type this_labels,

--- a/src/tensorwrapper/buffer/eigen.cpp
+++ b/src/tensorwrapper/buffer/eigen.cpp
@@ -151,6 +151,30 @@ typename EIGEN::dsl_reference EIGEN::permute_assignment_(
 }
 
 TPARAMS
+typename EIGEN::dsl_reference EIGEN::scalar_multiplication_(
+  label_type this_labels, double scalar, const_labeled_reference rhs) {
+    BufferBase::permute_assignment_(this_labels, rhs);
+
+    using allocator_type       = allocator::Eigen<FloatType, Rank>;
+    const auto& rhs_downcasted = allocator_type::rebind(rhs.object());
+
+    const auto& rlabels = rhs.labels();
+
+    FloatType c(scalar);
+
+    if(this_labels != rlabels) { // We need to permute rhs before assignment
+        auto r_to_l = rhs.labels().permutation(this_labels);
+        // Eigen wants int objects
+        std::vector<int> r_to_l2(r_to_l.begin(), r_to_l.end());
+        m_tensor_ = rhs_downcasted.value().shuffle(r_to_l2) * c;
+    } else {
+        m_tensor_ = rhs_downcasted.value() * c;
+    }
+
+    return *this;
+}
+
+TPARAMS
 typename detail_::PolymorphicBase<BufferBase>::string_type EIGEN::to_string_()
   const {
     std::stringstream ss;

--- a/src/tensorwrapper/tensor/tensor_class.cpp
+++ b/src/tensorwrapper/tensor/tensor_class.cpp
@@ -75,6 +75,8 @@ const_buffer_reference Tensor::buffer() const {
     return m_pimpl_->buffer();
 }
 
+Tensor::rank_type Tensor::rank() const { return logical_layout().rank(); }
+
 // -- Utility
 
 void Tensor::swap(Tensor& other) noexcept { m_pimpl_.swap(other.m_pimpl_); }
@@ -87,6 +89,114 @@ bool Tensor::operator==(const Tensor& rhs) const noexcept {
 
 bool Tensor::operator!=(const Tensor& rhs) const noexcept {
     return !(*this == rhs);
+}
+
+// -- Protected methods
+
+Tensor::dsl_reference Tensor::addition_assignment_(
+  label_type this_labels, const_labeled_reference lhs,
+  const_labeled_reference rhs) {
+    const auto& lobject = lhs.object();
+    const auto& llabels = lhs.labels();
+    const auto& robject = rhs.object();
+    const auto& rlabels = rhs.labels();
+
+    auto llayout      = lobject.logical_layout();
+    auto rlayout      = robject.logical_layout();
+    auto pthis_layout = llayout.clone_as<logical_layout_type>();
+
+    pthis_layout->addition_assignment(this_labels, llayout(llabels),
+                                      rlayout(rlabels));
+
+    auto pthis_buffer = lobject.buffer().clone();
+    auto lbuffer      = lobject.buffer()(llabels);
+    auto rbuffer      = robject.buffer()(rlabels);
+    pthis_buffer->addition_assignment(this_labels, lbuffer, rbuffer);
+
+    auto new_pimpl = std::make_unique<pimpl_type>(std::move(pthis_layout),
+                                                  std::move(pthis_buffer));
+    new_pimpl.swap(m_pimpl_);
+
+    return *this;
+}
+
+Tensor::dsl_reference Tensor::subtraction_assignment_(
+  label_type this_labels, const_labeled_reference lhs,
+  const_labeled_reference rhs) {
+    const auto& lobject = lhs.object();
+    const auto& llabels = lhs.labels();
+    const auto& robject = rhs.object();
+    const auto& rlabels = rhs.labels();
+
+    auto llayout      = lobject.logical_layout();
+    auto rlayout      = robject.logical_layout();
+    auto pthis_layout = llayout.clone_as<logical_layout_type>();
+
+    pthis_layout->subtraction_assignment(this_labels, llayout(llabels),
+                                         rlayout(rlabels));
+
+    auto pthis_buffer = lobject.buffer().clone();
+    auto lbuffer      = lobject.buffer()(llabels);
+    auto rbuffer      = robject.buffer()(rlabels);
+    pthis_buffer->subtraction_assignment(this_labels, lbuffer, rbuffer);
+
+    auto new_pimpl = std::make_unique<pimpl_type>(std::move(pthis_layout),
+                                                  std::move(pthis_buffer));
+    new_pimpl.swap(m_pimpl_);
+
+    return *this;
+}
+
+Tensor::dsl_reference Tensor::multiplication_assignment_(
+  label_type this_labels, const_labeled_reference lhs,
+  const_labeled_reference rhs) {
+    const auto& lobject = lhs.object();
+    const auto& llabels = lhs.labels();
+    const auto& robject = rhs.object();
+    const auto& rlabels = rhs.labels();
+
+    auto llayout      = lobject.logical_layout();
+    auto rlayout      = robject.logical_layout();
+    auto pthis_layout = llayout.clone_as<logical_layout_type>();
+
+    pthis_layout->multiplication_assignment(this_labels, llayout(llabels),
+                                            rlayout(rlabels));
+
+    auto pthis_buffer = lobject.buffer().clone();
+    auto lbuffer      = lobject.buffer()(llabels);
+    auto rbuffer      = robject.buffer()(rlabels);
+    pthis_buffer->multiplication_assignment(this_labels, lbuffer, rbuffer);
+
+    auto new_pimpl = std::make_unique<pimpl_type>(std::move(pthis_layout),
+                                                  std::move(pthis_buffer));
+    new_pimpl.swap(m_pimpl_);
+
+    return *this;
+}
+
+Tensor::dsl_reference Tensor::permute_assignment_(label_type this_labels,
+                                                  const_labeled_reference rhs) {
+    const auto& robject = rhs.object();
+    const auto& rlabels = rhs.labels();
+
+    auto rlayout      = robject.logical_layout();
+    auto pthis_layout = rlayout.clone_as<logical_layout_type>();
+
+    pthis_layout->permute_assignment(this_labels, rlayout(rlabels));
+
+    auto pthis_buffer = robject.buffer().clone();
+    auto rbuffer      = robject.buffer()(rlabels);
+    pthis_buffer->permute_assignment(this_labels, rbuffer);
+
+    auto new_pimpl = std::make_unique<pimpl_type>(std::move(pthis_layout),
+                                                  std::move(pthis_buffer));
+    new_pimpl.swap(m_pimpl_);
+
+    return *this;
+}
+
+typename Tensor::polymorphic_base::string_type Tensor::to_string_() const {
+    return has_pimpl_() ? buffer().to_string() : "";
 }
 
 // -- Private methods

--- a/src/tensorwrapper/tensor/tensor_class.cpp
+++ b/src/tensorwrapper/tensor/tensor_class.cpp
@@ -174,6 +174,27 @@ Tensor::dsl_reference Tensor::multiplication_assignment_(
     return *this;
 }
 
+Tensor::dsl_reference Tensor::scalar_multiplication_(
+  label_type this_labels, double scalar, const_labeled_reference rhs) {
+    const auto& robject = rhs.object();
+    const auto& rlabels = rhs.labels();
+
+    auto rlayout      = robject.logical_layout();
+    auto pthis_layout = rlayout.clone_as<logical_layout_type>();
+
+    pthis_layout->permute_assignment(this_labels, rlayout(rlabels));
+
+    auto pthis_buffer = robject.buffer().clone();
+    auto rbuffer      = robject.buffer()(rlabels);
+    pthis_buffer->scalar_multiplication(this_labels, scalar, rbuffer);
+
+    auto new_pimpl = std::make_unique<pimpl_type>(std::move(pthis_layout),
+                                                  std::move(pthis_buffer));
+    new_pimpl.swap(m_pimpl_);
+
+    return *this;
+}
+
 Tensor::dsl_reference Tensor::permute_assignment_(label_type this_labels,
                                                   const_labeled_reference rhs) {
     const auto& robject = rhs.object();

--- a/tests/cxx/unit_tests/tensorwrapper/buffer/eigen.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/buffer/eigen.cpp
@@ -461,6 +461,69 @@ TEMPLATE_TEST_CASE("Eigen", "", float, double) {
             }
         }
 
+        SECTION("scalar_multiplication_") {
+            SECTION("scalar") {
+                auto scalar2      = testing::eigen_scalar<TestType>();
+                scalar2.value()() = 42.0;
+
+                auto s        = scalar("");
+                auto pscalar2 = &(scalar2.scalar_multiplication("", 2.0, s));
+
+                auto corr      = testing::eigen_scalar<TestType>();
+                corr.value()() = 20.0;
+                REQUIRE(pscalar2 == &scalar2);
+                REQUIRE(scalar2 == corr);
+            }
+
+            SECTION("vector") {
+                auto vector2 = testing::eigen_vector<TestType>();
+
+                auto vi       = vector("i");
+                auto pvector2 = &(vector2.scalar_multiplication("i", 2.0, vi));
+
+                auto corr       = testing::eigen_vector<TestType>(2);
+                corr.value()(0) = 20.0;
+                corr.value()(1) = 40.0;
+
+                REQUIRE(pvector2 == &vector2);
+                REQUIRE(vector2 == corr);
+            }
+
+            SECTION("matrix : no permutation") {
+                auto matrix2 = testing::eigen_matrix<TestType>();
+
+                auto mij = matrix("i,j");
+                auto p   = &(matrix2.scalar_multiplication("i,j", 2.0, mij));
+
+                auto corr          = testing::eigen_matrix<TestType>(2, 3);
+                corr.value()(0, 0) = 20.0;
+                corr.value()(0, 1) = 40.0;
+                corr.value()(0, 2) = 60.0;
+                corr.value()(1, 0) = 80.0;
+                corr.value()(1, 1) = 100.0;
+                corr.value()(1, 2) = 120.0;
+
+                REQUIRE(p == &matrix2);
+                REQUIRE(matrix2 == corr);
+            }
+
+            SECTION("matrix: permutation") {
+                auto matrix2 = testing::eigen_matrix<TestType>();
+                auto mij     = matrix("i,j");
+                auto p = &(matrix2.scalar_multiplication("j,i", 2.0, mij));
+
+                auto corr          = testing::eigen_matrix<TestType>(3, 2);
+                corr.value()(0, 0) = 20.0;
+                corr.value()(1, 0) = 40.0;
+                corr.value()(2, 0) = 60.0;
+                corr.value()(0, 1) = 80.0;
+                corr.value()(1, 1) = 100.0;
+                corr.value()(2, 1) = 120.0;
+                REQUIRE(p == &matrix2);
+                compare_eigen<TestType>(corr.value(), matrix2.value());
+            }
+        }
+
         SECTION("hadamard_") {
             SECTION("scalar") {
                 scalar_buffer scalar2(eigen_scalar, scalar_layout);

--- a/tests/cxx/unit_tests/tensorwrapper/detail_/dsl_base.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/detail_/dsl_base.cpp
@@ -170,12 +170,23 @@ TEMPLATE_LIST_TEST_CASE("DSLBase", "", test_types) {
     }
 
     SECTION("scalar_multiplication") {
+        using error_t = std::runtime_error;
         // N.b., only tensor and buffer will override so here we're checking
         // that other objects throw
         if constexpr(std::is_same_v<TestType, Tensor>) {
+            auto s   = default_value("");
+            auto sij = default_value("i,j");
+
+            // Input's indices mush match rank
+            REQUIRE_THROWS_AS(value.scalar_multiplication("i,j", 2.0, sij),
+                              error_t);
+
+            // Output must have <= number of dummy indices
+            REQUIRE_THROWS_AS(value.scalar_multiplication("i,j", 2.0, s),
+                              error_t);
+
         } else {
-            using error_t = std::runtime_error;
-            auto s        = default_value("");
+            auto s = default_value("");
             REQUIRE_THROWS_AS(value.scalar_multiplication("", 1.0, s), error_t);
         }
     }

--- a/tests/cxx/unit_tests/tensorwrapper/detail_/dsl_base.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/detail_/dsl_base.cpp
@@ -172,9 +172,11 @@ TEMPLATE_LIST_TEST_CASE("DSLBase", "", test_types) {
     SECTION("scalar_multiplication") {
         // N.b., only tensor and buffer will override so here we're checking
         // that other objects throw
-        using error_t = std::runtime_error;
-
-        // Input's indices must match rank
-        REQUIRE_THROWS_AS(value.scalar_multiplication(1.0), error_t);
+        if constexpr(std::is_same_v<TestType, Tensor>) {
+        } else {
+            using error_t = std::runtime_error;
+            auto s        = default_value("");
+            REQUIRE_THROWS_AS(value.scalar_multiplication("", 1.0, s), error_t);
+        }
     }
 }

--- a/tests/cxx/unit_tests/tensorwrapper/dsl/dsl.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/dsl/dsl.cpp
@@ -62,6 +62,17 @@ TEMPLATE_LIST_TEST_CASE("DSL", "", testing::dsl_types) {
         value1.multiplication_assignment("i,j", value2("i,j"), value2("i,j"));
         REQUIRE(value1.are_equal(value0));
     }
+
+    SECTION("scalar_multiplication") {
+        if constexpr(std::is_same_v<TestType, Tensor>) {
+        } else {
+            // N.b., only tensor and buffer will override so here we're checking
+            // that other objects throw
+            using error_t = std::runtime_error;
+
+            REQUIRE_THROWS_AS(value0("") = value0("") * 1.0, error_t);
+        }
+    }
 }
 
 // Since Eigen buffers are templated on the rank there isn't an easy way to
@@ -109,9 +120,8 @@ TEST_CASE("DSLr : buffer::Eigen") {
     }
 
     SECTION("scalar_multiplication") {
-        // This should actually work. Will fix in a future PR
-        using error_t = std::runtime_error;
-
-        REQUIRE_THROWS_AS(scalar0("") = scalar0("") * 1.0, error_t);
+        scalar0("") = scalar1("") * 1.0;
+        corr.scalar_multiplication("", 1.0, scalar1(""));
+        REQUIRE(corr.are_equal(scalar0));
     }
 }

--- a/tests/cxx/unit_tests/tensorwrapper/dsl/pairwise_parser.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/dsl/pairwise_parser.cpp
@@ -95,11 +95,15 @@ TEMPLATE_LIST_TEST_CASE("PairwiseParser", "", testing::dsl_types) {
     }
 
     SECTION("scalar_multiplication") {
-        // N.b., only tensor and buffer will override so here we're checking
-        // that other objects throw
-        using error_t = std::runtime_error;
+        if constexpr(std::is_same_v<TestType, Tensor>) {
+        } else {
+            // N.b., only tensor and buffer will override so here we're checking
+            // that other objects throw
+            using error_t = std::runtime_error;
 
-        REQUIRE_THROWS_AS(p.dispatch(value0(""), value0("") * 1.0), error_t);
+            REQUIRE_THROWS_AS(p.dispatch(value0(""), value0("") * 1.0),
+                              error_t);
+        }
     }
 }
 
@@ -150,9 +154,8 @@ TEST_CASE("PairwiseParser : buffer::Eigen") {
     }
 
     SECTION("scalar_multiplication") {
-        // This should actually work. Will fix in a future PR
-        using error_t = std::runtime_error;
-
-        REQUIRE_THROWS_AS(p.dispatch(scalar0(""), scalar0("") * 1.0), error_t);
+        p.dispatch(scalar0(""), scalar1("") * 1.0);
+        corr.scalar_multiplication("", 1.0, scalar1(""));
+        REQUIRE(corr.are_equal(scalar0));
     }
 }

--- a/tests/cxx/unit_tests/tensorwrapper/dsl/pairwise_parser.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/dsl/pairwise_parser.cpp
@@ -96,6 +96,20 @@ TEMPLATE_LIST_TEST_CASE("PairwiseParser", "", testing::dsl_types) {
 
     SECTION("scalar_multiplication") {
         if constexpr(std::is_same_v<TestType, Tensor>) {
+            object_type rv(value1);
+            object_type corr(value1);
+
+            SECTION("scalar") {
+                p.dispatch(rv(""), value0("") * 2.0);
+                corr.scalar_multiplication("", 2.0, value0(""));
+                REQUIRE(corr.are_equal(rv));
+            }
+            SECTION("matrix") {
+                p.dispatch(rv("i,j"), value2("i,j") * 2.0);
+                corr.scalar_multiplication("i,j", 2.0, value2("i,j"));
+                REQUIRE(corr.are_equal(rv));
+            }
+
         } else {
             // N.b., only tensor and buffer will override so here we're checking
             // that other objects throw

--- a/tests/cxx/unit_tests/tensorwrapper/tensor/tensor_class.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/tensor/tensor_class.cpp
@@ -163,4 +163,80 @@ TEST_CASE("Tensor") {
         REQUIRE_FALSE(scalar != other_scalar);
         REQUIRE(scalar != vector);
     }
+
+    SECTION("addition_assignment") {
+        SECTION("scalar") {
+            Tensor rv;
+            Tensor s0(42.0);
+            auto prv = &(rv.addition_assignment("", s0(""), s0("")));
+            REQUIRE(prv == &rv);
+            Tensor corr(84.0);
+            REQUIRE(rv == corr);
+        }
+        SECTION("vector") {
+            Tensor rv;
+            Tensor v0{0, 1, 2, 3, 4};
+            auto prv = &(rv.addition_assignment("i", v0("i"), v0("i")));
+            REQUIRE(prv == &rv);
+            REQUIRE(rv == Tensor{0, 2, 4, 6, 8});
+        }
+    }
+    SECTION("subtraction_assignment") {
+        SECTION("scalar") {
+            Tensor rv;
+            Tensor s0(42.0);
+            auto prv = &(rv.subtraction_assignment("", s0(""), s0("")));
+            REQUIRE(prv == &rv);
+            REQUIRE(rv == Tensor(0.0));
+        }
+        SECTION("vector") {
+            Tensor rv;
+            Tensor v0{0, 1, 2, 3, 4};
+            auto prv = &(rv.subtraction_assignment("i", v0("i"), v0("i")));
+            REQUIRE(prv == &rv);
+            REQUIRE(rv == Tensor{0, 0, 0, 0, 0});
+        }
+    }
+    SECTION("multiplication_assignment") {
+        SECTION("scalar") {
+            Tensor rv;
+            Tensor s0(42.0);
+            auto prv = &(rv.multiplication_assignment("", s0(""), s0("")));
+            REQUIRE(prv == &rv);
+            Tensor corr(1764.0);
+            REQUIRE(rv == corr);
+        }
+        SECTION("vector") {
+            Tensor rv;
+            Tensor v0{0, 1, 2, 3, 4};
+            auto prv = &(rv.multiplication_assignment("i", v0("i"), v0("i")));
+            REQUIRE(prv == &rv);
+            REQUIRE(rv == Tensor{0, 1, 4, 9, 16});
+        }
+    }
+    SECTION("permute_assignment") {
+        SECTION("scalar") {
+            Tensor rv;
+            Tensor s0(42.0);
+            auto prv = &(rv.permute_assignment("", s0("")));
+            REQUIRE(prv == &rv);
+            Tensor corr(42.0);
+            REQUIRE(rv == corr);
+        }
+        SECTION("vector") {
+            Tensor rv;
+            Tensor v0{0, 1, 2, 3, 4};
+            auto prv = &(rv.permute_assignment("i", v0("i")));
+            REQUIRE(prv == &rv);
+            REQUIRE(rv == Tensor{0, 1, 2, 3, 4});
+        }
+        SECTION("matrix") {
+            Tensor rv;
+            Tensor m0{{1, 2}, {3, 4}};
+            auto prv = &(rv.permute_assignment("j,i", m0("i,j")));
+            REQUIRE(prv == &rv);
+            Tensor corr{{1, 3}, {2, 4}};
+            REQUIRE(rv == corr);
+        }
+    }
 }

--- a/tests/cxx/unit_tests/tensorwrapper/tensor/tensor_class.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/tensor/tensor_class.cpp
@@ -121,6 +121,13 @@ TEST_CASE("Tensor") {
         REQUIRE_THROWS_AS(const_defaulted.buffer(), std::runtime_error);
     }
 
+    SECTION("rank") {
+        REQUIRE(scalar.rank() == 0);
+        REQUIRE(vector.rank() == 1);
+
+        REQUIRE_THROWS_AS(defaulted.rank(), std::runtime_error);
+    }
+
     SECTION("swap") {
         Tensor scalar_copy(scalar);
         Tensor vector_copy(vector);
@@ -212,6 +219,31 @@ TEST_CASE("Tensor") {
             auto prv = &(rv.multiplication_assignment("i", v0("i"), v0("i")));
             REQUIRE(prv == &rv);
             REQUIRE(rv == Tensor{0, 1, 4, 9, 16});
+        }
+    }
+    SECTION("scalar_multiplication") {
+        SECTION("scalar") {
+            Tensor rv;
+            Tensor s0(42.0);
+            auto prv = &(rv.scalar_multiplication("", 2.0, s0("")));
+            REQUIRE(prv == &rv);
+            Tensor corr(84.0);
+            REQUIRE(rv == corr);
+        }
+        SECTION("vector") {
+            Tensor rv;
+            Tensor v0{0, 1, 2, 3, 4};
+            auto prv = &(rv.scalar_multiplication("i", 2.0, v0("i")));
+            REQUIRE(prv == &rv);
+            REQUIRE(rv == Tensor{0.0, 2.0, 4.0, 6.0, 8.0});
+        }
+        SECTION("matrix") {
+            Tensor rv;
+            Tensor m0{{1, 2}, {3, 4}};
+            auto prv = &(rv.scalar_multiplication("j,i", 2.0, m0("i,j")));
+            REQUIRE(prv == &rv);
+            Tensor corr{{2.0, 6.0}, {4.0, 8.0}};
+            REQUIRE(rv == corr);
         }
     }
     SECTION("permute_assignment") {

--- a/tests/cxx/unit_tests/tensorwrapper/testing/dsl.hpp
+++ b/tests/cxx/unit_tests/tensorwrapper/testing/dsl.hpp
@@ -25,24 +25,33 @@ namespace tensorwrapper::testing {
 using dsl_types =
   std::tuple<tensorwrapper::shape::Smooth, tensorwrapper::symmetry::Group,
              tensorwrapper::sparsity::Pattern, tensorwrapper::layout::Logical,
-             tensorwrapper::layout::Physical>;
+             tensorwrapper::layout::Physical, tensorwrapper::Tensor>;
 
 inline auto scalar_values() {
-    return dsl_types{smooth_scalar(), tensorwrapper::symmetry::Group(0),
-                     tensorwrapper::sparsity::Pattern(0), scalar_logical(),
-                     scalar_physical()};
+    return dsl_types{smooth_scalar(),
+                     tensorwrapper::symmetry::Group(0),
+                     tensorwrapper::sparsity::Pattern(0),
+                     scalar_logical(),
+                     scalar_physical(),
+                     Tensor(42.0)};
 }
 
 inline auto vector_values() {
-    return dsl_types{smooth_vector(), tensorwrapper::symmetry::Group(1),
-                     tensorwrapper::sparsity::Pattern(1), vector_logical(),
-                     vector_physical()};
+    return dsl_types{smooth_vector(),
+                     tensorwrapper::symmetry::Group(1),
+                     tensorwrapper::sparsity::Pattern(1),
+                     vector_logical(),
+                     vector_physical(),
+                     Tensor{1.0, 2.0, 3.0}};
 }
 
 inline auto matrix_values() {
-    return dsl_types{smooth_matrix(), tensorwrapper::symmetry::Group(2),
-                     tensorwrapper::sparsity::Pattern(2), matrix_logical(),
-                     matrix_physical()};
+    return dsl_types{smooth_matrix(),
+                     tensorwrapper::symmetry::Group(2),
+                     tensorwrapper::sparsity::Pattern(2),
+                     matrix_logical(),
+                     matrix_physical(),
+                     Tensor{{1.0, 2.0}, {3.0, 4.0}}};
 }
 
 } // namespace tensorwrapper::testing


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
With this PR the DSL now works at all relevant layers of TensorWrapper. This PR also implements scalar multiplication (although it's only from the right for the moment; from the left will require extending the DSL classes in utilities).

**TODOs**
None if GCC approves.
