### PR TITLE
adds contiguous class

### DIFF
--- a/include/tensorwrapper/buffer/contiguous.hpp
+++ b/include/tensorwrapper/buffer/contiguous.hpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <tensorwrapper/buffer/replicated.hpp>
+
+namespace tensorwrapper::buffer {
+
+/** @brief Denotes that a buffer is held contiguously.
+ *
+ *  Contiguous buffers are such that given a pointer to the first element `p`,
+ *  the `i`-th element (`i` is zero based) is given by dereferencing the
+ *  pointer `p + i`. Note that contiguous buffers are always vectors and storing
+ *  higher rank tensors in a contiguous buffer requires "vectorization" of the
+ *  tensor. In C++ vectorization is usually done in row-major format.
+ *
+ *  @tparam FloatType the type of elements in the buffer.
+ */
+template<typename FloatType>
+class Contiguous : public Replicated {
+private:
+    /// Type *this derives from
+    using my_base_type = Replicated;
+
+public:
+    /// Type of each element
+    using element_type = FloatType;
+
+    /// Type of a pointer to a mutable element_type object
+    using pointer = element_type*;
+
+    /// Type of a pointer to a read-only element_type object
+    using const_pointer = const element_type*;
+
+    /// Type used for offsets and indexing
+    using size_type = std::size_t;
+
+    // Pull in base's ctors
+    using my_base_type::my_base_type;
+
+    /// Returns the number of elements in contiguous memory
+    size_type size() const noexcept { return size_(); }
+
+    /// Returns a mutable pointer to the first element in contiguous memory
+    pointer data() noexcept { return data_(); }
+
+    /// Returns a read-only pointer to the first element in contiguous memory
+    const_pointer data() const noexcept { return data_(); }
+
+protected:
+    /// Derived class can override if it likes
+    virtual size_type size_() const noexcept { return layout().shape().size(); }
+
+    /// Derived class should implement according to data() description
+    virtual pointer data_() noexcept = 0;
+
+    /// Derived class should implement according to data() const description
+    virtual const_pointer data_() const noexcept = 0;
+};
+
+} // namespace tensorwrapper::buffer

--- a/src/tensorwrapper/buffer/eigen.cpp
+++ b/src/tensorwrapper/buffer/eigen.cpp
@@ -177,8 +177,7 @@ typename EIGEN::dsl_reference EIGEN::scalar_multiplication_(
 }
 
 TPARAMS
-typename detail_::PolymorphicBase<BufferBase>::string_type EIGEN::to_string_()
-  const {
+typename EIGEN::polymorphic_base::string_type EIGEN::to_string_() const {
     std::stringstream ss;
     ss << m_tensor_;
     return ss.str();

--- a/tests/cxx/unit_tests/tensorwrapper/buffer/contiguous.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/buffer/contiguous.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../testing/testing.hpp"
+#include <tensorwrapper/buffer/eigen.hpp>
+#include <tensorwrapper/layout/physical.hpp>
+#include <tensorwrapper/shape/smooth.hpp>
+
+using namespace tensorwrapper;
+using namespace buffer;
+
+/* Testing strategy:
+ *
+ * - Contiguous is an abstract class. To test it we must create an instance of
+ *   a derived class. We then will upcast to Contiguous and perform checks
+ *   through the BufferBase interface.
+
+ *
+ */
+
+TEMPLATE_LIST_TEST_CASE("Contiguous", "", testing::floating_point_types) {
+    using base_type = Contiguous<TestType>;
+    auto t0         = testing::eigen_scalar<TestType>();
+    auto t1         = testing::eigen_vector<TestType>();
+
+    auto& base0 = static_cast<base_type&>(t0);
+    auto& base1 = static_cast<base_type&>(t1);
+
+    SECTION("size") {
+        REQUIRE(base0.size() == 1);
+        REQUIRE(base1.size() == 5);
+    }
+
+    SECTION("data()") {
+        REQUIRE(*base0.data() == TestType(42.0));
+
+        REQUIRE(*(base1.data() + 0) == TestType(0.0));
+        REQUIRE(*(base1.data() + 1) == TestType(1.0));
+        REQUIRE(*(base1.data() + 2) == TestType(2.0));
+        REQUIRE(*(base1.data() + 3) == TestType(3.0));
+        REQUIRE(*(base1.data() + 4) == TestType(4.0));
+    }
+
+    SECTION("data() const") {
+        REQUIRE(*std::as_const(base0).data() == TestType(42.0));
+
+        REQUIRE(*(std::as_const(base1).data() + 0) == TestType(0.0));
+        REQUIRE(*(std::as_const(base1).data() + 1) == TestType(1.0));
+        REQUIRE(*(std::as_const(base1).data() + 2) == TestType(2.0));
+        REQUIRE(*(std::as_const(base1).data() + 3) == TestType(3.0));
+        REQUIRE(*(std::as_const(base1).data() + 4) == TestType(4.0));
+    }
+}

--- a/tests/cxx/unit_tests/tensorwrapper/buffer/eigen.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/buffer/eigen.cpp
@@ -22,12 +22,6 @@
 using namespace tensorwrapper;
 using namespace testing;
 
-#ifdef ENABLE_SIGMA
-using types2test = std::tuple<float, double, sigma::UFloat, sigma::UDouble>;
-#else
-using types2test = std::tuple<float, double>;
-#endif
-
 namespace {
 
 template<typename FloatType, typename LHSType, typename RHSType>
@@ -47,7 +41,7 @@ void compare_eigen(const LHSType& lhs, const RHSType& rhs) {
 
 } // namespace
 
-TEMPLATE_LIST_TEST_CASE("Eigen", "", types2test) {
+TEMPLATE_LIST_TEST_CASE("Eigen", "", testing::floating_point_types) {
     using scalar_buffer = buffer::Eigen<TestType, 0>;
     using vector_buffer = buffer::Eigen<TestType, 1>;
     using matrix_buffer = buffer::Eigen<TestType, 2>;

--- a/tests/cxx/unit_tests/tensorwrapper/testing/testing.hpp
+++ b/tests/cxx/unit_tests/tensorwrapper/testing/testing.hpp
@@ -21,3 +21,14 @@
 #include "inputs.hpp"
 #include "layouts.hpp"
 #include "shapes.hpp"
+
+namespace tensorwrapper::testing {
+
+#ifdef ENABLE_SIGMA
+using floating_point_types =
+  std::tuple<float, double, sigma::UFloat, sigma::UDouble>;
+#else
+using floating_point_types = std::tuple<float, double>;
+#endif
+
+} // namespace tensorwrapper::testing


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
My goal is to expose the `Tensor` class to Python through NumPy. To that end, I need access to the buffer. This PR extends the buffer's class hierarchy to include a `Contiguous` layer which adds `data()` and `size()` members.

**TODOs**
None if CI passes.