### PR TITLE
Print Precision Options

### DIFF
--- a/include/tensorwrapper/buffer/eigen.hpp
+++ b/include/tensorwrapper/buffer/eigen.hpp
@@ -224,6 +224,9 @@ protected:
     /// Implements to_string
     typename polymorphic_base::string_type to_string_() const override;
 
+    /// Implements add_to_stream
+    std::ostream& add_to_stream_(std::ostream& os) const override;
+
 private:
     /// True if *this has a PIMPL
     bool has_pimpl_() const noexcept;

--- a/include/tensorwrapper/detail_/polymorphic_base.hpp
+++ b/include/tensorwrapper/detail_/polymorphic_base.hpp
@@ -160,7 +160,7 @@ public:
      *
      *  @note This method is meant primarily for logging/debugging and NOT for
      *        serialization or archival.
-     * 
+     *
      *  @param[in] os The stream to add *this to.
      *
      *  @return The modified stream with *this added to it.

--- a/include/tensorwrapper/detail_/polymorphic_base.hpp
+++ b/include/tensorwrapper/detail_/polymorphic_base.hpp
@@ -153,6 +153,22 @@ public:
      */
     auto to_string() const { return to_string_(); }
 
+    /** @brief Adds a string representation of *this to the stream.
+     *
+     *  This uses `to_string` by default a polymorphic, but allows for better
+     *  optimization of the stream output for specific instances
+     *
+     *  @note This method is meant primarily for logging/debugging and NOT for
+     *        serialization or archival.
+     * 
+     *  @param[in] os The stream to add *this to.
+     *
+     *  @return The modified stream with *this added to it.
+     */
+    std::ostream& add_to_stream(std::ostream& os) const {
+        return add_to_stream_(os);
+    }
+
 protected:
     /** @brief No-op default ctor
      *
@@ -227,12 +243,17 @@ protected:
 
     /// Should be overridden by the derived class to provide logging details.
     virtual string_type to_string_() const { return "{?}"; }
+
+    /// Should be overridden by the derived class to provide logging details
+    virtual std::ostream& add_to_stream_(std::ostream& os) const {
+        return os << this->to_string();
+    }
 };
 
 /// Implements printing via ostream for objects deriving from PolymorphicBase
 template<typename T>
 inline std::ostream& operator<<(std::ostream& os, const PolymorphicBase<T>& b) {
-    return os << b.to_string();
+    return b.add_to_stream(os);
 }
 
 } // namespace tensorwrapper::detail_

--- a/src/tensorwrapper/buffer/detail_/eigen_tensor.hpp
+++ b/src/tensorwrapper/buffer/detail_/eigen_tensor.hpp
@@ -103,6 +103,10 @@ protected:
         return ss.str();
     }
 
+    std::ostream& add_to_stream_(std::ostream& os) const override {
+        return os << m_tensor_;
+    }
+
     void addition_assignment_(label_type this_labels, label_type lhs_labels,
                               label_type rhs_labels, const_pimpl_reference lhs,
                               const_pimpl_reference rhs) override;

--- a/src/tensorwrapper/buffer/eigen.cpp
+++ b/src/tensorwrapper/buffer/eigen.cpp
@@ -177,6 +177,10 @@ TPARAMS
 typename EIGEN::polymorphic_base::string_type EIGEN::to_string_() const {
     return m_pimpl_ ? m_pimpl_->to_string() : "";
 }
+TPARAMS
+std::ostream& EIGEN::add_to_stream_(std::ostream& os) const {
+    return m_pimpl_ ? m_pimpl_->add_to_stream(os) : os;
+}
 
 // -- Private methods
 

--- a/tests/cxx/unit_tests/tensorwrapper/buffer/detail_/eigen_tensor.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/buffer/detail_/eigen_tensor.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "../../testing/testing.hpp"
+#include <iomanip>
 #include <tensorwrapper/buffer/detail_/eigen_tensor.hpp>
 
 using namespace tensorwrapper;
@@ -196,6 +197,14 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
 
         REQUIRE(scalar.to_string() == sone.str());
         REQUIRE(vector.to_string() == sone.str() + " " + stwo.str());
+    }
+
+    SECTION("add_to_stream_") {
+        std::stringstream ss, ss_corr;
+        ss << std::fixed << std::setprecision(4);
+        scalar.add_to_stream(ss);
+        REQUIRE(ss.str() == "1.0000");
+        REQUIRE_FALSE(ss.str() == scalar.to_string());
     }
 
     SECTION("addition_assignment_") {

--- a/tests/cxx/unit_tests/tensorwrapper/buffer/detail_/eigen_tensor.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/buffer/detail_/eigen_tensor.cpp
@@ -203,7 +203,9 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
         std::stringstream ss, ss_corr;
         ss << std::fixed << std::setprecision(4);
         scalar.add_to_stream(ss);
-        REQUIRE(ss.str() == "1.0000");
+        ss_corr << std::fixed << std::setprecision(4);
+        ss_corr << TestType{1.0};
+        REQUIRE(ss.str() == ss_corr.str());
         REQUIRE_FALSE(ss.str() == scalar.to_string());
     }
 


### PR DESCRIPTION
**Description**
As is, stream output for classes derived from `PolymorphicBase` first converts to a string then adds the string to the stream output. This behavior prevents controlling the print precision of floating point values as they never see options like `std::fixed` or `std::setprecision`. This PR adds the `add_to_stream` method as an intermediate step that derived classes can use to more directly interact with the output stream, but defaults to the existing behavior for anything that doesn't implement `add_to_stream_`.