### PR TITLE
Define Contiguous Buffer

### DIFF
--- a/include/tensorwrapper/buffer/contiguous.hpp
+++ b/include/tensorwrapper/buffer/contiguous.hpp
@@ -17,6 +17,7 @@
 #pragma once
 #include <tensorwrapper/buffer/replicated.hpp>
 #include <tensorwrapper/detail_/integer_utilities.hpp>
+#include <tensorwrapper/types/floating_point.hpp>
 
 namespace tensorwrapper::buffer {
 
@@ -136,5 +137,11 @@ protected:
     /// Derived class should implement according to operator()()const
     virtual const_reference get_elem_(index_vector index) const = 0;
 };
+
+#define DECLARE_CONTIG_BUFFER(TYPE) extern template class Contiguous<TYPE>
+
+TW_APPLY_FLOATING_POINT_TYPES(DECLARE_CONTIG_BUFFER);
+
+#undef DECLARE_CONTIG_BUFFER
 
 } // namespace tensorwrapper::buffer

--- a/src/tensorwrapper/buffer/contiguoues.cpp
+++ b/src/tensorwrapper/buffer/contiguoues.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <tensorwrapper/buffer/contiguous.hpp>
+
+namespace tensorwrapper::buffer {
+
+#define DEFINE_CONTIG_BUFFER(TYPE) template class Contiguous<TYPE>
+
+TW_APPLY_FLOATING_POINT_TYPES(DEFINE_CONTIG_BUFFER);
+
+#undef DEFINE_CONTIG_BUFFER
+
+} // namespace tensorwrapper::buffer


### PR DESCRIPTION
**Description**
Resolves the errors in the clang tests seen in NWChemEx/StructureFinder#5, NWChemEx/FriendZone#21, and NWChemEx/FriendZone#22.

Without an explicit definition, seems clang isn't able to ensure one in different units. This results in failure for [this dynamic cast](https://github.com/NWChemEx/TensorWrapper/blob/7dcf2d1592700775a2ef8beb1252aefd42c2eb43/src/python/tensor/export_tensor.cpp#L78) when it should be successful. The `runtime_error` seems to get swallowed up by Python or NumPy, which hid the problem.