### PR TITLE
Eigen Tensor Comparison

### DIFF
--- a/src/tensorwrapper/buffer/detail_/eigen_tensor.hpp
+++ b/src/tensorwrapper/buffer/detail_/eigen_tensor.hpp
@@ -63,10 +63,10 @@ public:
     const_eigen_reference value() const noexcept { return m_tensor_; }
     ///@}
 
-    /// Tests for exact equality by taking the difference and comparing to 0.0
+    /// Tests for exact equality
     bool operator==(const my_type& rhs) const noexcept {
-        eigen::data_type<FloatType, 0> r = (m_tensor_ - rhs.m_tensor_).sum();
-        return r() == FloatType(0.0);
+        eigen::data_type<bool, 0> eq = (m_tensor_ == rhs.m_tensor_).all();
+        return eq();
     }
 
 protected:

--- a/tests/cxx/unit_tests/tensorwrapper/buffer/detail_/eigen_tensor.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/buffer/detail_/eigen_tensor.cpp
@@ -62,6 +62,15 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
 
         scalar2.get_elem({}) = 42.0;
         REQUIRE_FALSE(scalar2 == scalar);
+
+        if constexpr(types::is_uncertain_v<TestType>) {
+            SECTION("Check Error Sources Match") {
+                pimpl_type<TestType, 0> uscalar(shape_type{});
+                uscalar.get_elem({}) = TestType(1.0, 0.0);
+                pimpl_type<TestType, 0> uscalar2(uscalar);
+                REQUIRE(uscalar2 == uscalar);
+            }
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -250,12 +259,12 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
 
             pimpl_type<TestType, 3> corr(shape_type{2, 2, 2});
             corr.get_elem({0, 0, 0}) = 2.0;
-            corr.get_elem({0, 0, 1}) = 8.0;
-            corr.get_elem({0, 1, 0}) = 8.0;
-            corr.get_elem({0, 1, 1}) = 14.0;
-            corr.get_elem({1, 0, 0}) = 4.0;
-            corr.get_elem({1, 0, 1}) = 10.0;
-            corr.get_elem({1, 1, 0}) = 10.0;
+            corr.get_elem({0, 0, 1}) = 7.0;
+            corr.get_elem({0, 1, 0}) = 6.0;
+            corr.get_elem({0, 1, 1}) = 11.0;
+            corr.get_elem({1, 0, 0}) = 7.0;
+            corr.get_elem({1, 0, 1}) = 12.0;
+            corr.get_elem({1, 1, 0}) = 11.0;
             corr.get_elem({1, 1, 1}) = 16.0;
             REQUIRE(output == corr);
         }
@@ -270,12 +279,12 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
 
             pimpl_type<TestType, 3> corr(shape_type{2, 2, 2});
             corr.get_elem({0, 0, 0}) = 2.0;
-            corr.get_elem({0, 0, 1}) = 8.0;
-            corr.get_elem({0, 1, 0}) = 8.0;
-            corr.get_elem({0, 1, 1}) = 14.0;
-            corr.get_elem({1, 0, 0}) = 4.0;
-            corr.get_elem({1, 0, 1}) = 10.0;
-            corr.get_elem({1, 1, 0}) = 10.0;
+            corr.get_elem({0, 0, 1}) = 7.0;
+            corr.get_elem({0, 1, 0}) = 6.0;
+            corr.get_elem({0, 1, 1}) = 11.0;
+            corr.get_elem({1, 0, 0}) = 7.0;
+            corr.get_elem({1, 0, 1}) = 12.0;
+            corr.get_elem({1, 1, 0}) = 11.0;
             corr.get_elem({1, 1, 1}) = 16.0;
             REQUIRE(output == corr);
         }


### PR DESCRIPTION
**Description**
The current method of comparing `EigenTensor`s fails in certain cases. Currently, the difference between two tensors is summed and compared to zero. In general, this method has an issue when the differences of the individual terms are not zero but their sum is zero (as was happening in the changed unit test). Specifically for `sigma::uncertain` values, the comparison to `FloatType(0.0)` would almost never return true since the difference values still track error sources whose contributions have been negated up to that point. This PR updates the comparison operator for `EigenTensor` to an element-wise boolean comparison and then reducing those values.