### PR TITLE
Buffer API update

### DIFF
--- a/include/tensorwrapper/buffer/buffer_base.hpp
+++ b/include/tensorwrapper/buffer/buffer_base.hpp
@@ -28,8 +28,8 @@ namespace tensorwrapper::buffer {
  *
  *  All classes which wrap existing tensor libraries derive from this class.
  */
-class BufferBase : public detail_::PolymorphicBase<BufferBase>,
-                   public detail_::DSLBase<BufferBase> {
+class BufferBase : public tensorwrapper::detail_::PolymorphicBase<BufferBase>,
+                   public tensorwrapper::detail_::DSLBase<BufferBase> {
 private:
     /// Type of *this
     using my_type = BufferBase;
@@ -39,7 +39,7 @@ private:
 
 protected:
     /// Type *this inherits from
-    using polymorphic_base = detail_::PolymorphicBase<my_type>;
+    using polymorphic_base = tensorwrapper::detail_::PolymorphicBase<my_type>;
 
 public:
     /// Type all buffers inherit from

--- a/include/tensorwrapper/buffer/contiguous.hpp
+++ b/include/tensorwrapper/buffer/contiguous.hpp
@@ -47,7 +47,7 @@ public:
     /// Type of a read-only reference to an object of type element_type
     using const_reference = const element_type&;
 
-    using elements_type = std::vector<element_type>;
+    using element_vector = std::vector<element_type>;
 
     /// Type of a pointer to a mutable element_type object
     using pointer = element_type*;
@@ -164,9 +164,15 @@ public:
      *
      *  @throw None No throw guarantee.
      */
-    void fill(element_type value) { fill_(value); }
+    void fill(element_type value) { fill_(std::move(value)); }
 
-    void copy(elements_type& values) { copy_(values); }
+    /** @brief Sets elements using a list of values.
+     *
+     *  @param[in] values The new values of all elements.
+     *
+     *  @throw None No throw guarantee.
+     */
+    void copy(const element_vector& values) { copy_(values); }
 
 protected:
     /// Derived class can override if it likes
@@ -193,7 +199,7 @@ protected:
     /// Derived class should implement according to fill()
     virtual void fill_(element_type) = 0;
 
-    virtual void copy_(elements_type& values) = 0;
+    virtual void copy_(const element_vector& values) = 0;
 };
 
 #define DECLARE_CONTIG_BUFFER(TYPE) extern template class Contiguous<TYPE>

--- a/include/tensorwrapper/buffer/contiguous.hpp
+++ b/include/tensorwrapper/buffer/contiguous.hpp
@@ -66,7 +66,7 @@ public:
     size_type size() const noexcept { return size_(); }
 
     /// Returns a mutable pointer to the first element in contiguous memory
-    pointer data() noexcept { return data_(); }
+    pointer get_mutable_data() noexcept { return get_mutable_data_(); }
 
     /// Returns a read-only pointer to the first element in contiguous memory
     const_pointer data() const noexcept { return data_(); }
@@ -121,12 +121,24 @@ public:
           index_vector{detail_::to_size_t(std::forward<Args>(args))...});
     }
 
+    const_reference get_elem(index_vector index) const {
+        if(index.size() == this->rank())
+            throw std::runtime_error("Number of offsets must match rank");
+        return get_elem_(index);
+    }
+
+    void set_elem(index_vector index, element_type new_value) {
+        if(index.size() == this->rank())
+            throw std::runtime_error("Number of offsets must match rank");
+        return set_elem_(index, new_value);
+    }
+
 protected:
     /// Derived class can override if it likes
     virtual size_type size_() const noexcept { return layout().shape().size(); }
 
     /// Derived class should implement according to data() description
-    virtual pointer data_() noexcept = 0;
+    virtual pointer get_mutable_data_() noexcept = 0;
 
     /// Derived class should implement according to data() const description
     virtual const_pointer data_() const noexcept = 0;
@@ -134,8 +146,11 @@ protected:
     /// Derived class should implement according to operator()()
     virtual reference get_elem_(index_vector index) = 0;
 
-    /// Derived class should implement according to operator()()const
+    /// Derived class should implement according to get_elem()
     virtual const_reference get_elem_(index_vector index) const = 0;
+
+    /// Derived class should implement according to set_elem()
+    virtual void set_elem_(index_vector index, element_type new_value) = 0;
 };
 
 #define DECLARE_CONTIG_BUFFER(TYPE) extern template class Contiguous<TYPE>

--- a/include/tensorwrapper/buffer/contiguous.hpp
+++ b/include/tensorwrapper/buffer/contiguous.hpp
@@ -47,6 +47,8 @@ public:
     /// Type of a read-only reference to an object of type element_type
     using const_reference = const element_type&;
 
+    using elements_type = std::vector<element_type>;
+
     /// Type of a pointer to a mutable element_type object
     using pointer = element_type*;
 
@@ -65,73 +67,106 @@ public:
     /// Returns the number of elements in contiguous memory
     size_type size() const noexcept { return size_(); }
 
-    /// Returns a mutable pointer to the first element in contiguous memory
+    /** @brief Returns a mutable pointer to the first element in contiguous
+     *         memory
+     *
+     *  @warning Returning a mutable pointer to the underlying data makes it
+     *           no longer possible for *this to reliably track changes to that
+     *           data. Calling this method may have performance implications, so
+     *           use only when strictly required.
+     *
+     *  @return A read/write pointer to the data.
+     *
+     *  @throw None No throw guarantee.
+     */
     pointer get_mutable_data() noexcept { return get_mutable_data_(); }
 
-    /// Returns a read-only pointer to the first element in contiguous memory
-    const_pointer data() const noexcept { return data_(); }
-
-    /** @brief Retrieves a tensor element by offset.
+    /** @brief Returns an immutable pointer to the first element in contiguous
+     *         memory
      *
-     *  @tparam Args The types of each offset. Must decay to integral types.
+     *  @return A read-only pointer to the data.
      *
-     *  @param[in] args The offsets such that the i-th value in @p args is the
-     *                  offset of the element along the i-th mode of the tensor.
-     *
-     *  @return A mutable reference to the element.
-     *
-     *  @throw std::runtime_error if the number of indices does not match the
-     *                            rank of the tensor. Strong throw guarantee.
+     *  @throw None No throw guarantee.
      */
-    template<typename... Args>
-    reference at(Args&&... args) {
-        static_assert(
-          std::conjunction_v<std::is_integral<std::decay_t<Args>>...>,
-          "Offsets must be integral types");
-        if(sizeof...(Args) != this->rank())
-            throw std::runtime_error("Number of offsets must match rank");
-        return get_elem_(
-          index_vector{detail_::to_size_t(std::forward<Args>(args))...});
+    const_pointer get_immutable_data() const noexcept {
+        return get_immutable_data_();
     }
 
     /** @brief Retrieves a tensor element by offset.
      *
-     *  @tparam Args The types of each offset. Must decay to integral types.
+     *  This method is used to access the element in an immutable way.
      *
-     *  This method is the same as the non-const version except that the result
-     *  is read-only. See the documentation for the mutable version for more
-     *  details.
-     *
-     *  @param[in] args The offsets such that the i-th value in @p args is the
-     *                  offset of the element along the i-th mode of the tensor.
+     *  @param[in] index The offset of the element being retrieved.
      *
      *  @return A read-only reference to the element.
      *
      *  @throw std::runtime_error if the number of indices does not match the
      *                            rank of the tensor. Strong throw guarantee.
      */
-    template<typename... Args>
-    const_reference at(Args&&... args) const {
-        static_assert(
-          std::conjunction_v<std::is_integral<std::decay_t<Args>>...>,
-          "Offsets must be integral types");
-        if(sizeof...(Args) != this->rank())
-            throw std::runtime_error("Number of offsets must match rank");
-        return get_elem_(
-          index_vector{detail_::to_size_t(std::forward<Args>(args))...});
-    }
-
     const_reference get_elem(index_vector index) const {
-        if(index.size() == this->rank())
+        if(index.size() != this->rank())
             throw std::runtime_error("Number of offsets must match rank");
         return get_elem_(index);
     }
 
+    /** @brief Sets a tensor element by offset.
+     *
+     *  This method is used to change the value of an element.
+     *
+     *  @param[in] index The offset of the element being updated.
+     *  @param[in] new_value The new value of the element.
+     *
+     *  @throw std::runtime_error if the number of indices does not match the
+     *                            rank of the tensor. Strong throw guarantee.
+     */
     void set_elem(index_vector index, element_type new_value) {
-        if(index.size() == this->rank())
+        if(index.size() != this->rank())
             throw std::runtime_error("Number of offsets must match rank");
         return set_elem_(index, new_value);
     }
+
+    /** @brief Retrieves a tensor element by ordinal offset.
+     *
+     *  This method is used to access the element in an immutable way.
+     *
+     *  @param[in] index The ordinal offset of the element being retrieved.
+     *
+     *  @return A read-only reference to the element.
+     *
+     *  @throw std::runtime_error if the index is greater than the number of
+     *                            elements. Strong throw guarantee.
+     */
+    const_reference get_data(size_type index) const {
+        if(index >= this->size())
+            throw std::runtime_error("Index greater than number of elements");
+        return get_data_(std::move(index));
+    }
+
+    /** @brief Sets a tensor element by ordinal offset.
+     *
+     *  This method is used to change the value of an element.
+     *
+     *  @param[in] index The ordinal offset of the element being updated.
+     *  @param[in] new_value The new value of the element.
+     *
+     *  @throw std::runtime_error if the index is greater than the number of
+     *                            elements. Strong throw guarantee.
+     */
+    void set_data(size_type index, element_type new_value) {
+        if(index >= this->size())
+            throw std::runtime_error("Index greater than number of elements");
+        set_data_(index, new_value);
+    }
+
+    /** @brief Sets all elements to a value.
+     *
+     *  @param[in] value The new value of all elements.
+     *
+     *  @throw None No throw guarantee.
+     */
+    void fill(element_type value) { fill_(value); }
+
+    void copy(elements_type& values) { copy_(values); }
 
 protected:
     /// Derived class can override if it likes
@@ -141,16 +176,24 @@ protected:
     virtual pointer get_mutable_data_() noexcept = 0;
 
     /// Derived class should implement according to data() const description
-    virtual const_pointer data_() const noexcept = 0;
-
-    /// Derived class should implement according to operator()()
-    virtual reference get_elem_(index_vector index) = 0;
+    virtual const_pointer get_immutable_data_() const noexcept = 0;
 
     /// Derived class should implement according to get_elem()
     virtual const_reference get_elem_(index_vector index) const = 0;
 
     /// Derived class should implement according to set_elem()
     virtual void set_elem_(index_vector index, element_type new_value) = 0;
+
+    /// Derived class should implement according to get_data()
+    virtual const_reference get_data_(size_type index) const = 0;
+
+    /// Derived class should implement according to set_data()
+    virtual void set_data_(size_type index, element_type new_value) = 0;
+
+    /// Derived class should implement according to fill()
+    virtual void fill_(element_type) = 0;
+
+    virtual void copy_(elements_type& values) = 0;
 };
 
 #define DECLARE_CONTIG_BUFFER(TYPE) extern template class Contiguous<TYPE>

--- a/include/tensorwrapper/buffer/eigen.hpp
+++ b/include/tensorwrapper/buffer/eigen.hpp
@@ -53,7 +53,7 @@ public:
     using typename my_base_type::const_reference;
     using typename my_base_type::dsl_reference;
     using typename my_base_type::element_type;
-    using typename my_base_type::elements_type;
+    using typename my_base_type::element_vector;
     using typename my_base_type::index_vector;
     using typename my_base_type::label_type;
     using typename my_base_type::layout_pointer;
@@ -232,7 +232,8 @@ protected:
     /// Implements filling the tensor
     void fill_(element_type value) override;
 
-    void copy_(elements_type& values) override;
+    /// Implements copying new values into the tensor
+    void copy_(const element_vector& values) override;
 
     /// Implements to_string
     typename polymorphic_base::string_type to_string_() const override;

--- a/include/tensorwrapper/buffer/eigen.hpp
+++ b/include/tensorwrapper/buffer/eigen.hpp
@@ -211,7 +211,7 @@ protected:
                                          const_labeled_reference rhs) override;
 
     /// Implements getting the raw pointer
-    pointer data_() noexcept override;
+    pointer get_mutable_data_() noexcept override;
 
     /// Implements getting the raw pointer (read-only)
     const_pointer data_() const noexcept override;
@@ -221,6 +221,8 @@ protected:
 
     /// Implements read-only element access
     const_reference get_elem_(index_vector index) const override;
+
+    void set_elem_(index_vector index, element_type new_value) override;
 
     /// Implements to_string
     typename polymorphic_base::string_type to_string_() const override;

--- a/include/tensorwrapper/buffer/eigen.hpp
+++ b/include/tensorwrapper/buffer/eigen.hpp
@@ -53,6 +53,7 @@ public:
     using typename my_base_type::const_reference;
     using typename my_base_type::dsl_reference;
     using typename my_base_type::element_type;
+    using typename my_base_type::elements_type;
     using typename my_base_type::index_vector;
     using typename my_base_type::label_type;
     using typename my_base_type::layout_pointer;
@@ -214,15 +215,24 @@ protected:
     pointer get_mutable_data_() noexcept override;
 
     /// Implements getting the raw pointer (read-only)
-    const_pointer data_() const noexcept override;
-
-    /// Implements mutable element access
-    reference get_elem_(index_vector index) override;
+    const_pointer get_immutable_data_() const noexcept override;
 
     /// Implements read-only element access
     const_reference get_elem_(index_vector index) const override;
 
+    // Implements element updating
     void set_elem_(index_vector index, element_type new_value) override;
+
+    /// Implements read-only element access by ordinal index
+    const_reference get_data_(size_type index) const override;
+
+    // Implements element updating by ordinal index
+    void set_data_(size_type index, element_type new_value) override;
+
+    /// Implements filling the tensor
+    void fill_(element_type value) override;
+
+    void copy_(elements_type& values) override;
 
     /// Implements to_string
     typename polymorphic_base::string_type to_string_() const override;

--- a/include/tensorwrapper/buffer/eigen.hpp
+++ b/include/tensorwrapper/buffer/eigen.hpp
@@ -52,6 +52,7 @@ public:
     using typename my_base_type::const_pointer;
     using typename my_base_type::const_reference;
     using typename my_base_type::dsl_reference;
+    using typename my_base_type::element_type;
     using typename my_base_type::index_vector;
     using typename my_base_type::label_type;
     using typename my_base_type::layout_pointer;

--- a/src/python/tensor/export_tensor.cpp
+++ b/src/python/tensor/export_tensor.cpp
@@ -39,8 +39,8 @@ auto make_buffer_info(buffer::Contiguous<FloatType>& buffer) {
             stride_i *= smooth_shape.extent(mode_i);
         strides[rank_i] = stride_i * nbytes;
     }
-    return pybind11::buffer_info(buffer.data(), nbytes, desc, rank, shape,
-                                 strides);
+    return pybind11::buffer_info(buffer.get_mutable_data(), nbytes, desc, rank,
+                                 shape, strides);
 }
 
 auto make_tensor(pybind11::buffer b) {

--- a/src/python/tensor/export_tensor.cpp
+++ b/src/python/tensor/export_tensor.cpp
@@ -60,8 +60,8 @@ auto make_tensor(pybind11::buffer b) {
 
     auto n_elements = std::accumulate(dims.begin(), dims.end(), 1,
                                       std::multiplies<std::size_t>());
-    for(auto i = 0; i < n_elements; ++i)
-        pBuffer->data()[i] = static_cast<double*>(info.ptr)[i];
+    auto pData      = static_cast<double*>(info.ptr);
+    for(auto i = 0; i < n_elements; ++i) pBuffer->set_data(i, pData[i]);
 
     return Tensor(matrix_shape, std::move(pBuffer));
 }

--- a/src/tensorwrapper/allocator/eigen.cpp
+++ b/src/tensorwrapper/allocator/eigen.cpp
@@ -100,8 +100,7 @@ typename EIGEN::contiguous_pointer EIGEN::construct_(layout_pointer playout,
                                                      element_type value) {
     auto pbuffer        = this->allocate(std::move(playout));
     auto& contig_buffer = static_cast<buffer::Contiguous<FloatType>&>(*pbuffer);
-    auto* pdata         = contig_buffer.data();
-    std::fill(pdata, pdata + contig_buffer.size(), value);
+    contig_buffer.fill(value);
     return pbuffer;
 }
 
@@ -115,7 +114,7 @@ typename EIGEN::contiguous_pointer EIGEN::il_construct_(ILType il) {
     auto playout      = std::make_unique<layout::Physical>(std::move(shape));
     auto pbuffer      = this->allocate(std::move(playout));
     auto& buffer_down = rebind(*pbuffer);
-    std::copy(data.begin(), data.end(), buffer_down.data());
+    buffer_down.copy(data);
     return pbuffer;
 }
 

--- a/src/tensorwrapper/buffer/detail_/eigen_pimpl.hpp
+++ b/src/tensorwrapper/buffer/detail_/eigen_pimpl.hpp
@@ -33,6 +33,7 @@ public:
     using parent_type           = Eigen<FloatType>;
     using pimpl_pointer         = typename parent_type::pimpl_pointer;
     using label_type            = typename parent_type::label_type;
+    using element_type          = typename parent_type::element_type;
     using reference             = typename parent_type::reference;
     using const_shape_reference = const shape::ShapeBase&;
     using const_reference       = typename parent_type::const_reference;

--- a/src/tensorwrapper/buffer/detail_/eigen_pimpl.hpp
+++ b/src/tensorwrapper/buffer/detail_/eigen_pimpl.hpp
@@ -34,6 +34,7 @@ public:
     using pimpl_pointer         = typename parent_type::pimpl_pointer;
     using label_type            = typename parent_type::label_type;
     using element_type          = typename parent_type::element_type;
+    using elements_type         = typename parent_type::elements_type;
     using reference             = typename parent_type::reference;
     using const_shape_reference = const shape::ShapeBase&;
     using const_reference       = typename parent_type::const_reference;
@@ -58,11 +59,8 @@ public:
 
     pointer get_mutable_data() noexcept { return get_mutable_data_(); }
 
-    const_pointer data() const noexcept { return data_(); }
-
-    reference get_elem(index_vector index) {
-        assert(index.size() == rank());
-        return get_elem_(std::move(index));
+    const_pointer get_immutable_data() const noexcept {
+        return get_immutable_data_();
     }
 
     const_reference get_elem(index_vector index) const {
@@ -75,14 +73,21 @@ public:
         set_elem_(index, new_value);
     }
 
-    const_reference get_data_at(size_type index) const {
+    const_reference get_data(size_type index) const {
         assert(index < size());
-        return get_data_at_(std::move(index));
+        return get_data_(std::move(index));
     }
 
-    void set_data_at(size_type index, element_type new_value) {
+    void set_data(size_type index, element_type new_value) {
         assert(index < size());
-        set_data_at_(index, new_value);
+        set_data_(index, new_value);
+    }
+
+    void fill(element_type value) { fill_(value); }
+
+    void copy(elements_type& values) {
+        assert(values.size() <= size());
+        copy_(values);
     }
 
     void addition_assignment(label_type this_labels, label_type lhs_labels,
@@ -132,12 +137,13 @@ protected:
     virtual size_type size_() const                                    = 0;
     virtual size_type extent_(eigen_rank_type i) const                 = 0;
     virtual pointer get_mutable_data_() noexcept                       = 0;
-    virtual const_pointer data_() const noexcept                       = 0;
-    virtual reference get_elem_(index_vector index)                    = 0;
+    virtual const_pointer get_immutable_data_() const noexcept         = 0;
     virtual const_reference get_elem_(index_vector index) const        = 0;
     virtual void set_elem_(index_vector index, element_type new_value) = 0;
-    virtual const_reference get_data_at_(size_type index) const        = 0;
-    virtual void set_data_at_(size_type index, element_type new_value) = 0;
+    virtual const_reference get_data_(size_type index) const           = 0;
+    virtual void set_data_(size_type index, element_type new_value)    = 0;
+    virtual void fill_(element_type value)                             = 0;
+    virtual void copy_(elements_type& values)                          = 0;
     virtual void addition_assignment_(label_type this_labels,
                                       label_type lhs_labels,
                                       label_type rhs_labels,

--- a/src/tensorwrapper/buffer/detail_/eigen_pimpl.hpp
+++ b/src/tensorwrapper/buffer/detail_/eigen_pimpl.hpp
@@ -49,12 +49,14 @@ public:
 
     eigen_rank_type rank() const noexcept { return rank_(); }
 
+    size_type size() const noexcept { return size_(); }
+
     size_type extent(eigen_rank_type i) const {
         assert(i < rank());
         return extent_(i);
     }
 
-    pointer data() noexcept { return data_(); }
+    pointer get_mutable_data() noexcept { return get_mutable_data_(); }
 
     const_pointer data() const noexcept { return data_(); }
 
@@ -66,6 +68,21 @@ public:
     const_reference get_elem(index_vector index) const {
         assert(index.size() == rank());
         return get_elem_(std::move(index));
+    }
+
+    void set_elem(index_vector index, element_type new_value) {
+        assert(index.size() == rank());
+        set_elem_(index, new_value);
+    }
+
+    const_reference get_data_at(size_type index) const {
+        assert(index < size());
+        return get_data_at_(std::move(index));
+    }
+
+    void set_data_at(size_type index, element_type new_value) {
+        assert(index < size());
+        set_data_at_(index, new_value);
     }
 
     void addition_assignment(label_type this_labels, label_type lhs_labels,
@@ -111,39 +128,43 @@ public:
     }
 
 protected:
-    virtual eigen_rank_type rank_() const noexcept                  = 0;
-    virtual size_type extent_(eigen_rank_type i) const              = 0;
-    virtual pointer data_() noexcept                                = 0;
-    virtual const_pointer data_() const noexcept                    = 0;
-    virtual reference get_elem_(index_vector index)                 = 0;
-    virtual const_reference get_elem_(index_vector index) const     = 0;
+    virtual eigen_rank_type rank_() const noexcept                     = 0;
+    virtual size_type size_() const                                    = 0;
+    virtual size_type extent_(eigen_rank_type i) const                 = 0;
+    virtual pointer get_mutable_data_() noexcept                       = 0;
+    virtual const_pointer data_() const noexcept                       = 0;
+    virtual reference get_elem_(index_vector index)                    = 0;
+    virtual const_reference get_elem_(index_vector index) const        = 0;
+    virtual void set_elem_(index_vector index, element_type new_value) = 0;
+    virtual const_reference get_data_at_(size_type index) const        = 0;
+    virtual void set_data_at_(size_type index, element_type new_value) = 0;
     virtual void addition_assignment_(label_type this_labels,
                                       label_type lhs_labels,
                                       label_type rhs_labels,
                                       const_pimpl_reference lhs,
-                                      const_pimpl_reference rhs)    = 0;
+                                      const_pimpl_reference rhs)       = 0;
     virtual void subtraction_assignment_(label_type this_labels,
                                          label_type lhs_labels,
                                          label_type rhs_labels,
                                          const_pimpl_reference lhs,
-                                         const_pimpl_reference rhs) = 0;
+                                         const_pimpl_reference rhs)    = 0;
     virtual void hadamard_assignment_(label_type this_labels,
                                       label_type lhs_labels,
                                       label_type rhs_labels,
                                       const_pimpl_reference lhs,
-                                      const_pimpl_reference rhs)    = 0;
+                                      const_pimpl_reference rhs)       = 0;
     virtual void contraction_assignment_(label_type this_labels,
                                          label_type lhs_labels,
                                          label_type rhs_labels,
                                          const_shape_reference result_shape,
                                          const_pimpl_reference lhs,
-                                         const_pimpl_reference rhs) = 0;
+                                         const_pimpl_reference rhs)    = 0;
     virtual void permute_assignment_(label_type this_labels,
                                      label_type rhs_labels,
-                                     const_pimpl_reference rhs)     = 0;
+                                     const_pimpl_reference rhs)        = 0;
     virtual void scalar_multiplication_(label_type this_labels,
                                         label_type rhs_labels, FloatType scalar,
-                                        const_pimpl_reference rhs)  = 0;
+                                        const_pimpl_reference rhs)     = 0;
 };
 
 } // namespace tensorwrapper::buffer::detail_

--- a/src/tensorwrapper/buffer/detail_/eigen_pimpl.hpp
+++ b/src/tensorwrapper/buffer/detail_/eigen_pimpl.hpp
@@ -34,7 +34,7 @@ public:
     using pimpl_pointer         = typename parent_type::pimpl_pointer;
     using label_type            = typename parent_type::label_type;
     using element_type          = typename parent_type::element_type;
-    using elements_type         = typename parent_type::elements_type;
+    using element_vector        = typename parent_type::element_vector;
     using reference             = typename parent_type::reference;
     using const_shape_reference = const shape::ShapeBase&;
     using const_reference       = typename parent_type::const_reference;
@@ -83,9 +83,9 @@ public:
         set_data_(index, new_value);
     }
 
-    void fill(element_type value) { fill_(value); }
+    void fill(element_type value) { fill_(std::move(value)); }
 
-    void copy(elements_type& values) {
+    void copy(const element_vector& values) {
         assert(values.size() <= size());
         copy_(values);
     }
@@ -143,7 +143,7 @@ protected:
     virtual const_reference get_data_(size_type index) const           = 0;
     virtual void set_data_(size_type index, element_type new_value)    = 0;
     virtual void fill_(element_type value)                             = 0;
-    virtual void copy_(elements_type& values)                          = 0;
+    virtual void copy_(const element_vector& values)                   = 0;
     virtual void addition_assignment_(label_type this_labels,
                                       label_type lhs_labels,
                                       label_type rhs_labels,

--- a/src/tensorwrapper/buffer/detail_/eigen_tensor.cpp
+++ b/src/tensorwrapper/buffer/detail_/eigen_tensor.cpp
@@ -24,11 +24,6 @@ namespace tensorwrapper::buffer::detail_ {
 #define EIGEN_TENSOR EigenTensor<FloatType, Rank>
 
 TPARAMS
-bool EIGEN_TENSOR::operator==(const my_type& rhs) const noexcept {
-    return get_hash() == rhs.get_hash();
-}
-
-TPARAMS
 template<typename OperationType>
 void EIGEN_TENSOR::element_wise_op_(OperationType op, label_type this_labels,
                                     label_type lhs_labels,
@@ -212,9 +207,9 @@ TPARAMS
 void EIGEN_TENSOR::update_hash_() const {
     m_hash_ = hash_type{rank_()};
     for(eigen_rank_type i = 0; i < rank_(); ++i)
-        hash_utilities::hash_input(m_hash_, extent_(i));
+        hash_utilities::hash_input(m_hash_, m_tensor_.dimension(i));
     for(auto i = 0; i < m_tensor_.size(); ++i)
-        hash_utilities::hash_input(m_hash_, data_()[i]);
+        hash_utilities::hash_input(m_hash_, m_tensor_.data()[i]);
     m_recalculate_hash_ = false;
 }
 

--- a/src/tensorwrapper/buffer/detail_/eigen_tensor.cpp
+++ b/src/tensorwrapper/buffer/detail_/eigen_tensor.cpp
@@ -24,6 +24,12 @@ namespace tensorwrapper::buffer::detail_ {
 #define EIGEN_TENSOR EigenTensor<FloatType, Rank>
 
 TPARAMS
+bool EIGEN_TENSOR::operator==(const my_type& rhs) const noexcept {
+    eigen::data_type<bool, 0> eq = (m_tensor_ == rhs.m_tensor_).all();
+    return eq();
+}
+
+TPARAMS
 template<typename OperationType>
 void EIGEN_TENSOR::element_wise_op_(OperationType op, label_type this_labels,
                                     label_type lhs_labels,

--- a/src/tensorwrapper/buffer/detail_/eigen_tensor.cpp
+++ b/src/tensorwrapper/buffer/detail_/eigen_tensor.cpp
@@ -37,9 +37,9 @@ void EIGEN_TENSOR::element_wise_op_(OperationType op, label_type this_labels,
                                     const_pimpl_reference rhs) {
     // Downcast LHS and RHS
     const auto* lhs_down  = dynamic_cast<const my_type*>(&lhs);
-    const auto& lhs_eigen = lhs_down->value();
+    const auto& lhs_eigen = lhs_down->m_tensor_;
     const auto* rhs_down  = dynamic_cast<const my_type*>(&rhs);
-    const auto& rhs_eigen = rhs_down->value();
+    const auto& rhs_eigen = rhs_down->m_tensor_;
 
     // Whose indices match whose?
     bool this_matches_lhs = (this_labels == lhs_labels);
@@ -171,9 +171,9 @@ void EIGEN_TENSOR::permute_assignment_(label_type this_labels,
         auto r_to_l = this_labels.permutation(rhs_labels);
         // Eigen wants int objects
         std::vector<int> r_to_l2(r_to_l.begin(), r_to_l.end());
-        m_tensor_ = rhs_down->value().shuffle(r_to_l2);
+        m_tensor_ = rhs_down->m_tensor_.shuffle(r_to_l2);
     } else {
-        m_tensor_ = rhs_down->value();
+        m_tensor_ = rhs_down->m_tensor_;
     }
     mark_for_rehash_();
 }
@@ -189,9 +189,9 @@ void EIGEN_TENSOR::scalar_multiplication_(label_type this_labels,
         auto r_to_l = rhs_labels.permutation(this_labels);
         // Eigen wants int objects
         std::vector<int> r_to_l2(r_to_l.begin(), r_to_l.end());
-        m_tensor_ = rhs_downcasted->value().shuffle(r_to_l2) * scalar;
+        m_tensor_ = rhs_downcasted->m_tensor_.shuffle(r_to_l2) * scalar;
     } else {
-        m_tensor_ = rhs_downcasted->value() * scalar;
+        m_tensor_ = rhs_downcasted->m_tensor_ * scalar;
     }
     mark_for_rehash_();
 }

--- a/src/tensorwrapper/buffer/detail_/eigen_tensor.cpp
+++ b/src/tensorwrapper/buffer/detail_/eigen_tensor.cpp
@@ -117,8 +117,8 @@ void EIGEN_TENSOR::contraction_assignment_(label_type olabels,
 
     eigen::data_type<FloatType, 2> buffer(lrows, rcols);
 
-    map_t lmatrix(lt->data(), lrows, lcols);
-    map_t rmatrix(rt->data(), rrows, rcols);
+    map_t lmatrix(lt->get_mutable_data(), lrows, lcols);
+    map_t rmatrix(rt->get_mutable_data(), rrows, rcols);
     map_t omatrix(buffer.data(), lrows, rcols);
     omatrix = lmatrix * rmatrix;
 

--- a/src/tensorwrapper/buffer/detail_/eigen_tensor.hpp
+++ b/src/tensorwrapper/buffer/detail_/eigen_tensor.hpp
@@ -120,7 +120,7 @@ protected:
         std::fill(m_tensor_.data(), m_tensor_.data() + m_tensor_.size(), value);
     }
 
-    void copy_(elements_type& values) {
+    void copy_(elements_type& values) override {
         mark_for_rehash_();
         std::copy(values.begin(), values.end(), m_tensor_.data());
     }

--- a/src/tensorwrapper/buffer/detail_/eigen_tensor.hpp
+++ b/src/tensorwrapper/buffer/detail_/eigen_tensor.hpp
@@ -38,6 +38,7 @@ public:
     using typename base_type::const_shape_reference;
     using typename base_type::eigen_rank_type;
     using typename base_type::index_vector;
+    using typename base_type::element_type;
     using typename base_type::label_type;
     using typename base_type::pimpl_pointer;
     using typename base_type::pointer;
@@ -58,15 +59,6 @@ public:
     explicit EigenTensor(const_smooth_view_reference shape) :
       m_tensor_(allocate_from_shape_(shape, std::make_index_sequence<Rank>())) {
     }
-
-    /// Get a mutable/read-only reference to the Eigen tensor object
-    ///@{
-    eigen_reference value() noexcept {
-        mark_for_rehash_();
-        return m_tensor_;
-    }
-    const_eigen_reference value() const noexcept { return m_tensor_; }
-    ///@}
 
     /// Tests for exact equality
     bool operator==(const my_type& rhs) const noexcept;

--- a/src/tensorwrapper/buffer/detail_/eigen_tensor.hpp
+++ b/src/tensorwrapper/buffer/detail_/eigen_tensor.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 #include "eigen_pimpl.hpp"
+#include "hash_utilities.hpp"
 #include <sstream>
 #include <tensorwrapper/detail_/integer_utilities.hpp>
 #include <tensorwrapper/shape/smooth.hpp>
@@ -65,6 +66,29 @@ public:
 
     /// Tests for exact equality
     bool operator==(const my_type& rhs) const noexcept;
+
+    using hash_type = hash_utilities::hash_type;
+
+    hash_type get_hash_() const {
+        if(m_hash_flag_) update_hash_();
+        return m_hash_;
+    }
+
+    // Computes the hash for the current state of *this
+    void update_hash_() const {
+        m_hash_ = hash_type{rank_()};
+        for(eigen_rank_type i = 0; i < rank_(); ++i)
+            hash_utilities::hash_input(m_hash_, extent_(i));
+        for(auto i = 0; i < m_tensor_.size(); ++i)
+            hash_utilities::hash_input(m_hash_, data_()[i]);
+        m_hash_flag_ = false;
+    }
+
+    // Tracks whether the hash needs to be redetermined
+    mutable bool m_hash_flag_ = true;
+
+    // Holds the computed hash value for this instance's state
+    mutable hash_type m_hash_;
 
 protected:
     pimpl_pointer clone_() const override {

--- a/src/tensorwrapper/buffer/detail_/eigen_tensor.hpp
+++ b/src/tensorwrapper/buffer/detail_/eigen_tensor.hpp
@@ -38,7 +38,7 @@ public:
     using typename base_type::const_shape_reference;
     using typename base_type::eigen_rank_type;
     using typename base_type::element_type;
-    using typename base_type::elements_type;
+    using typename base_type::element_vector;
     using typename base_type::index_vector;
     using typename base_type::label_type;
     using typename base_type::pimpl_pointer;
@@ -120,7 +120,7 @@ protected:
         std::fill(m_tensor_.data(), m_tensor_.data() + m_tensor_.size(), value);
     }
 
-    void copy_(elements_type& values) override {
+    void copy_(const element_vector& values) override {
         mark_for_rehash_();
         std::copy(values.begin(), values.end(), m_tensor_.data());
     }

--- a/src/tensorwrapper/buffer/detail_/eigen_tensor.hpp
+++ b/src/tensorwrapper/buffer/detail_/eigen_tensor.hpp
@@ -64,10 +64,7 @@ public:
     ///@}
 
     /// Tests for exact equality
-    bool operator==(const my_type& rhs) const noexcept {
-        eigen::data_type<bool, 0> eq = (m_tensor_ == rhs.m_tensor_).all();
-        return eq();
-    }
+    bool operator==(const my_type& rhs) const noexcept;
 
 protected:
     pimpl_pointer clone_() const override {

--- a/src/tensorwrapper/buffer/detail_/hash_utilities.hpp
+++ b/src/tensorwrapper/buffer/detail_/hash_utilities.hpp
@@ -18,19 +18,54 @@
 #include <boost/container_hash/hash.hpp>
 #include <tensorwrapper/types/floating_point.hpp>
 
+/** @namespace tensorwrapper::buffer::detail_::hash_utilities
+ *  @brief Utilities for hashing EigenTensor instances
+ */
 namespace tensorwrapper::buffer::detail_::hash_utilities {
 
+/// The type of a hash
 using hash_type = std::size_t;
 
+/** @brief Adds the hash of an input value to the seed hash
+ *
+ *  @tparam InputType The type of the value being added to the hash
+ *  @param[in,out] seed The initial value of the hash, which is overwritten when
+ *                      the new value is added.
+ *  @param[in] value The new value being hashed and combined with the @p seed.
+ *
+ *  @return The updated hash value
+ *
+ *  @throw none No throw guarantee
+ */
 template<typename InputType>
 void hash_input(hash_type& seed, const InputType& value) {
     boost::hash_combine(seed, value);
 }
 
+#ifdef ENABLE_SIGMA
+
+/** @brief Specialization for sigma::Uncertain values
+ *
+ *  @tparam T The floating point type of the uncertain value
+ *  @param[in,out] seed The initial value of the hash, which is overwritten when
+ *                      the new value is added.
+ *  @param[in] value The new uncertain value being hashed and combined with the
+ *                   seed.
+ *
+ *  @return The updated hash value
+ *
+ *  @throw none No throw guarantee
+ */
 template<typename T>
 void hash_input(hash_type& seed, const sigma::Uncertain<T>& value) {
-    boost::hash_combine(seed, value.mean());
-    boost::hash_combine(seed, value.sd());
+    hash_input(seed, value.mean());
+    hash_input(seed, value.sd());
+    for(const auto& [dep, deriv] : value.deps()) {
+        hash_input(seed, dep);
+        hash_input(seed, deriv);
+    }
 }
+
+#endif
 
 } // namespace tensorwrapper::buffer::detail_::hash_utilities

--- a/src/tensorwrapper/buffer/detail_/hash_utilities.hpp
+++ b/src/tensorwrapper/buffer/detail_/hash_utilities.hpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <boost/container_hash/hash.hpp>
+#include <tensorwrapper/types/floating_point.hpp>
+
+namespace tensorwrapper::buffer::detail_::hash_utilities {
+
+using hash_type = std::size_t;
+
+template<typename InputType>
+void hash_input(hash_type& seed, const InputType& value) {
+    boost::hash_combine(seed, value);
+}
+
+template<typename T>
+void hash_input(hash_type& seed, const sigma::Uncertain<T>& value) {
+    boost::hash_combine(seed, value.mean());
+    boost::hash_combine(seed, value.sd());
+}
+
+} // namespace tensorwrapper::buffer::detail_::hash_utilities

--- a/src/tensorwrapper/buffer/eigen.cpp
+++ b/src/tensorwrapper/buffer/eigen.cpp
@@ -190,9 +190,7 @@ void EIGEN::fill_(element_type value) {
 }
 
 TPARAMS
-void EIGEN::copy_(elements_type& values) {
-    return pimpl_().copy(values);
-}
+void EIGEN::copy_(elements_type& values) { return pimpl_().copy(values); }
 
 TPARAMS
 typename EIGEN::polymorphic_base::string_type EIGEN::to_string_() const {

--- a/src/tensorwrapper/buffer/eigen.cpp
+++ b/src/tensorwrapper/buffer/eigen.cpp
@@ -160,13 +160,8 @@ typename EIGEN::pointer EIGEN::get_mutable_data_() noexcept {
 }
 
 TPARAMS
-typename EIGEN::const_pointer EIGEN::data_() const noexcept {
-    return m_pimpl_ ? m_pimpl_->data() : nullptr;
-}
-
-TPARAMS
-typename EIGEN::reference EIGEN::get_elem_(index_vector index) {
-    return pimpl_().get_elem(std::move(index));
+typename EIGEN::const_pointer EIGEN::get_immutable_data_() const noexcept {
+    return m_pimpl_ ? m_pimpl_->get_immutable_data() : nullptr;
 }
 
 TPARAMS
@@ -177,6 +172,26 @@ typename EIGEN::const_reference EIGEN::get_elem_(index_vector index) const {
 TPARAMS
 void EIGEN::set_elem_(index_vector index, element_type new_value) {
     return pimpl_().set_elem(std::move(index), std::move(new_value));
+}
+
+TPARAMS
+typename EIGEN::const_reference EIGEN::get_data_(size_type index) const {
+    return pimpl_().get_data(std::move(index));
+}
+
+TPARAMS
+void EIGEN::set_data_(size_type index, element_type new_value) {
+    return pimpl_().set_data(std::move(index), std::move(new_value));
+}
+
+TPARAMS
+void EIGEN::fill_(element_type value) {
+    return pimpl_().fill(std::move(value));
+}
+
+TPARAMS
+void EIGEN::copy_(elements_type& values) {
+    return pimpl_().copy(values);
 }
 
 TPARAMS

--- a/src/tensorwrapper/buffer/eigen.cpp
+++ b/src/tensorwrapper/buffer/eigen.cpp
@@ -155,8 +155,8 @@ typename EIGEN::dsl_reference EIGEN::scalar_multiplication_(
 }
 
 TPARAMS
-typename EIGEN::pointer EIGEN::data_() noexcept {
-    return m_pimpl_ ? m_pimpl_->data() : nullptr;
+typename EIGEN::pointer EIGEN::get_mutable_data_() noexcept {
+    return m_pimpl_ ? m_pimpl_->get_mutable_data() : nullptr;
 }
 
 TPARAMS
@@ -173,10 +173,17 @@ TPARAMS
 typename EIGEN::const_reference EIGEN::get_elem_(index_vector index) const {
     return pimpl_().get_elem(std::move(index));
 }
+
+TPARAMS
+void EIGEN::set_elem_(index_vector index, element_type new_value) {
+    return pimpl_().set_elem(std::move(index), std::move(new_value));
+}
+
 TPARAMS
 typename EIGEN::polymorphic_base::string_type EIGEN::to_string_() const {
     return m_pimpl_ ? m_pimpl_->to_string() : "";
 }
+
 TPARAMS
 std::ostream& EIGEN::add_to_stream_(std::ostream& os) const {
     return m_pimpl_ ? m_pimpl_->add_to_stream(os) : os;

--- a/src/tensorwrapper/buffer/eigen.cpp
+++ b/src/tensorwrapper/buffer/eigen.cpp
@@ -190,7 +190,9 @@ void EIGEN::fill_(element_type value) {
 }
 
 TPARAMS
-void EIGEN::copy_(elements_type& values) { return pimpl_().copy(values); }
+void EIGEN::copy_(const element_vector& values) {
+    return pimpl_().copy(values);
+}
 
 TPARAMS
 typename EIGEN::polymorphic_base::string_type EIGEN::to_string_() const {

--- a/src/tensorwrapper/operations/approximately_equal.cpp
+++ b/src/tensorwrapper/operations/approximately_equal.cpp
@@ -31,7 +31,7 @@ struct Kernel {
         auto& buffer_down    = allocator_type::rebind(result);
 
         for(std::size_t i = 0; i < buffer_down.size(); ++i) {
-            auto diff = *(buffer_down.data() + i);
+            auto diff = buffer_down.get_data(i);
             if(diff < zero) diff *= -1.0;
             if(diff >= ptol) return false;
         }

--- a/src/tensorwrapper/operations/norm.cpp
+++ b/src/tensorwrapper/operations/norm.cpp
@@ -29,7 +29,7 @@ struct InfinityKernel {
         FloatType max_element{0.0};
         const auto& buffer_down = alloc.rebind(t);
         for(std::size_t i = 0; i < buffer_down.size(); ++i) {
-            auto elem = types::fabs(*(buffer_down.data() + i));
+            auto elem = types::fabs(buffer_down.get_data(i));
             if(elem > max_element) max_element = elem;
         }
         shape::Smooth s{};

--- a/tests/cxx/unit_tests/tensorwrapper/allocator/contiguous.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/allocator/contiguous.cpp
@@ -31,18 +31,18 @@ TEMPLATE_LIST_TEST_CASE("allocator::Contiguous", "",
     auto matrix_corr = testing::eigen_matrix<TestType>();
 
     SECTION("allocate(layout)") {
-        auto pscalar  = alloc.allocate(scalar_corr->layout());
-        pscalar->at() = 42.0;
+        auto pscalar = alloc.allocate(scalar_corr->layout());
+        pscalar->set_data(0, 42.0);
         REQUIRE(pscalar->are_equal(*scalar_corr));
     }
 
     SECTION("allocate(layout*)") {
-        auto pvector   = alloc.allocate(vector_corr->layout());
-        pvector->at(0) = 0.0;
-        pvector->at(1) = 1.0;
-        pvector->at(2) = 2.0;
-        pvector->at(3) = 3.0;
-        pvector->at(4) = 4.0;
+        auto pvector = alloc.allocate(vector_corr->layout());
+        pvector->set_data(0, 0.0);
+        pvector->set_data(1, 1.0);
+        pvector->set_data(2, 2.0);
+        pvector->set_data(3, 3.0);
+        pvector->set_data(4, 4.0);
 
         REQUIRE(pvector->are_equal(*vector_corr));
     }
@@ -79,11 +79,11 @@ TEMPLATE_LIST_TEST_CASE("allocator::Contiguous", "",
     }
 
     SECTION("construct(layout, value)") {
-        auto pmatrix          = alloc.construct(matrix_corr->layout(), 0.0);
-        matrix_corr->at(0, 0) = 0.0;
-        matrix_corr->at(0, 1) = 0.0;
-        matrix_corr->at(1, 0) = 0.0;
-        matrix_corr->at(1, 1) = 0.0;
+        auto pmatrix = alloc.construct(matrix_corr->layout(), 0.0);
+        matrix_corr->set_elem({0, 0}, 0.0);
+        matrix_corr->set_elem({0, 1}, 0.0);
+        matrix_corr->set_elem({1, 0}, 0.0);
+        matrix_corr->set_elem({1, 1}, 0.0);
 
         REQUIRE(pmatrix->are_equal(*matrix_corr));
     }
@@ -91,10 +91,10 @@ TEMPLATE_LIST_TEST_CASE("allocator::Contiguous", "",
     SECTION("construct(layout*, value)") {
         auto pmatrix = alloc.construct(
           matrix_corr->layout().template clone_as<layout_type>(), 0.0);
-        matrix_corr->at(0, 0) = 0.0;
-        matrix_corr->at(0, 1) = 0.0;
-        matrix_corr->at(1, 0) = 0.0;
-        matrix_corr->at(1, 1) = 0.0;
+        matrix_corr->set_elem({0, 0}, 0.0);
+        matrix_corr->set_elem({0, 1}, 0.0);
+        matrix_corr->set_elem({1, 0}, 0.0);
+        matrix_corr->set_elem({1, 1}, 0.0);
 
         REQUIRE(pmatrix->are_equal(*matrix_corr));
     }

--- a/tests/cxx/unit_tests/tensorwrapper/allocator/eigen.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/allocator/eigen.cpp
@@ -35,19 +35,19 @@ TEMPLATE_LIST_TEST_CASE("EigenAllocator", "", types2test) {
 
     auto pscalar_corr = testing::eigen_scalar<TestType>();
     auto& scalar_corr = *pscalar_corr;
-    scalar_corr.at()  = 0.0;
+    scalar_corr.set_elem({}, 0.0);
 
     auto pvector_corr = testing::eigen_vector<TestType>(2);
     auto& vector_corr = *pvector_corr;
-    vector_corr.at(0) = 1;
-    vector_corr.at(1) = 1;
+    vector_corr.set_elem({0}, 1);
+    vector_corr.set_elem({1}, 1);
 
-    auto pmatrix_corr    = testing::eigen_matrix<TestType>(2, 2);
-    auto& matrix_corr    = *pmatrix_corr;
-    matrix_corr.at(0, 0) = 2;
-    matrix_corr.at(0, 1) = 2;
-    matrix_corr.at(1, 0) = 2;
-    matrix_corr.at(1, 1) = 2;
+    auto pmatrix_corr = testing::eigen_matrix<TestType>(2, 2);
+    auto& matrix_corr = *pmatrix_corr;
+    matrix_corr.set_elem({0, 0}, 2);
+    matrix_corr.set_elem({0, 1}, 2);
+    matrix_corr.set_elem({1, 0}, 2);
+    matrix_corr.set_elem({1, 1}, 2);
 
     alloc_type alloc(rv);
 

--- a/tests/cxx/unit_tests/tensorwrapper/buffer/buffer_base.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/buffer/buffer_base.cpp
@@ -36,13 +36,13 @@ using namespace buffer;
 TEST_CASE("BufferBase") {
     auto pscalar = testing::eigen_scalar<double>();
     auto& scalar = *pscalar;
-    scalar.at()  = 1.0;
+    scalar.set_elem({}, 1.0);
 
     auto pvector = testing::eigen_vector<double>(2);
     auto& vector = *pvector;
 
-    vector.at(0) = 1.0;
-    vector.at(1) = 2.0;
+    vector.set_elem({0}, 1.0);
+    vector.set_elem({1}, 2.0);
 
     auto scalar_layout = testing::scalar_physical();
     auto vector_layout = testing::vector_physical(2);

--- a/tests/cxx/unit_tests/tensorwrapper/buffer/contiguous.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/buffer/contiguous.cpp
@@ -46,14 +46,14 @@ TEMPLATE_LIST_TEST_CASE("buffer::Contiguous", "", types::floating_point_types) {
         REQUIRE(base1.size() == 5);
     }
 
-    SECTION("data()") {
-        REQUIRE(*base0.data() == TestType(42.0));
+    SECTION("get_mutable_data()") {
+        REQUIRE(*base0.get_mutable_data() == TestType(42.0));
 
-        REQUIRE(*(base1.data() + 0) == TestType(0.0));
-        REQUIRE(*(base1.data() + 1) == TestType(1.0));
-        REQUIRE(*(base1.data() + 2) == TestType(2.0));
-        REQUIRE(*(base1.data() + 3) == TestType(3.0));
-        REQUIRE(*(base1.data() + 4) == TestType(4.0));
+        REQUIRE(*(base1.get_mutable_data() + 0) == TestType(0.0));
+        REQUIRE(*(base1.get_mutable_data() + 1) == TestType(1.0));
+        REQUIRE(*(base1.get_mutable_data() + 2) == TestType(2.0));
+        REQUIRE(*(base1.get_mutable_data() + 3) == TestType(3.0));
+        REQUIRE(*(base1.get_mutable_data() + 4) == TestType(4.0));
     }
 
     SECTION("data() const") {

--- a/tests/cxx/unit_tests/tensorwrapper/buffer/contiguous.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/buffer/contiguous.cpp
@@ -56,39 +56,79 @@ TEMPLATE_LIST_TEST_CASE("buffer::Contiguous", "", types::floating_point_types) {
         REQUIRE(*(base1.get_mutable_data() + 4) == TestType(4.0));
     }
 
-    SECTION("data() const") {
-        REQUIRE(*std::as_const(base0).data() == TestType(42.0));
+    SECTION("get_immutable_data() const") {
+        REQUIRE(*std::as_const(base0).get_immutable_data() == TestType(42.0));
 
-        REQUIRE(*(std::as_const(base1).data() + 0) == TestType(0.0));
-        REQUIRE(*(std::as_const(base1).data() + 1) == TestType(1.0));
-        REQUIRE(*(std::as_const(base1).data() + 2) == TestType(2.0));
-        REQUIRE(*(std::as_const(base1).data() + 3) == TestType(3.0));
-        REQUIRE(*(std::as_const(base1).data() + 4) == TestType(4.0));
+        REQUIRE(*(std::as_const(base1).get_immutable_data() + 0) ==
+                TestType(0.0));
+        REQUIRE(*(std::as_const(base1).get_immutable_data() + 1) ==
+                TestType(1.0));
+        REQUIRE(*(std::as_const(base1).get_immutable_data() + 2) ==
+                TestType(2.0));
+        REQUIRE(*(std::as_const(base1).get_immutable_data() + 3) ==
+                TestType(3.0));
+        REQUIRE(*(std::as_const(base1).get_immutable_data() + 4) ==
+                TestType(4.0));
     }
 
-    SECTION("at()") {
-        REQUIRE(base0.at() == TestType(42.0));
+    SECTION("get_elem() const") {
+        REQUIRE(base0.get_elem({}) == TestType(42.0));
 
-        REQUIRE(base1.at(0) == TestType(0.0));
-        REQUIRE(base1.at(1) == TestType(1.0));
-        REQUIRE(base1.at(2) == TestType(2.0));
-        REQUIRE(base1.at(3) == TestType(3.0));
-        REQUIRE(base1.at(4) == TestType(4.0));
+        REQUIRE(base1.get_elem({0}) == TestType(0.0));
+        REQUIRE(base1.get_elem({1}) == TestType(1.0));
+        REQUIRE(base1.get_elem({2}) == TestType(2.0));
+        REQUIRE(base1.get_elem({3}) == TestType(3.0));
+        REQUIRE(base1.get_elem({4}) == TestType(4.0));
 
-        REQUIRE_THROWS_AS(base0.at(0), std::runtime_error);
-        REQUIRE_THROWS_AS(base1.at(0, 1), std::runtime_error);
+        REQUIRE_THROWS_AS(base0.get_elem({0}), std::runtime_error);
     }
 
-    SECTION("at()const") {
-        REQUIRE(std::as_const(base0).at() == TestType(42.0));
+    SECTION("set_elem() const") {
+        base0.set_elem({}, TestType(43.0));
+        REQUIRE(base0.get_elem({}) == TestType(43.0));
 
-        REQUIRE(std::as_const(base1).at(0) == TestType(0.0));
-        REQUIRE(std::as_const(base1).at(1) == TestType(1.0));
-        REQUIRE(std::as_const(base1).at(2) == TestType(2.0));
-        REQUIRE(std::as_const(base1).at(3) == TestType(3.0));
-        REQUIRE(std::as_const(base1).at(4) == TestType(4.0));
+        base1.set_elem({0}, TestType(43.0));
+        REQUIRE(base1.get_elem({0}) == TestType(43.0));
 
-        REQUIRE_THROWS_AS(std::as_const(base0).at(0), std::runtime_error);
-        REQUIRE_THROWS_AS(std::as_const(base1).at(0, 1), std::runtime_error);
+        REQUIRE_THROWS_AS(base0.set_elem({0}, TestType{0.0}),
+                          std::runtime_error);
+    }
+
+    SECTION("get_data() const") {
+        REQUIRE(base0.get_data(0) == TestType(42.0));
+
+        REQUIRE(base1.get_data(0) == TestType(0.0));
+        REQUIRE(base1.get_data(1) == TestType(1.0));
+        REQUIRE(base1.get_data(2) == TestType(2.0));
+        REQUIRE(base1.get_data(3) == TestType(3.0));
+        REQUIRE(base1.get_data(4) == TestType(4.0));
+
+        REQUIRE_THROWS_AS(base0.get_data(1), std::runtime_error);
+    }
+
+    SECTION("set_data() const") {
+        base0.set_data(0, TestType(43.0));
+        REQUIRE(base0.get_elem({}) == TestType(43.0));
+
+        REQUIRE_THROWS_AS(base0.set_data(1, TestType{0.0}), std::runtime_error);
+    }
+
+    SECTION("fill()") {
+        base1.fill(TestType{43.0});
+        REQUIRE(base1.get_data(0) == TestType(43.0));
+        REQUIRE(base1.get_data(1) == TestType(43.0));
+        REQUIRE(base1.get_data(2) == TestType(43.0));
+        REQUIRE(base1.get_data(3) == TestType(43.0));
+        REQUIRE(base1.get_data(4) == TestType(43.0));
+    }
+
+    SECTION("copy()") {
+        auto data = std::vector<TestType>(5, TestType(43.0));
+        base1.copy(data);
+        REQUIRE(base1.get_data(0) == TestType(43.0));
+        REQUIRE(base1.get_data(1) == TestType(43.0));
+        REQUIRE(base1.get_data(2) == TestType(43.0));
+        REQUIRE(base1.get_data(3) == TestType(43.0));
+        REQUIRE(base1.get_data(4) == TestType(43.0));
     }
 }

--- a/tests/cxx/unit_tests/tensorwrapper/buffer/detail_/eigen_tensor.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/buffer/detail_/eigen_tensor.cpp
@@ -73,6 +73,16 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
         }
     }
 
+    SECTION("Hashing") {
+        auto scalar_hash = std::as_const(scalar).get_hash_();
+        auto matrix_hash = std::as_const(matrix).get_hash_();
+        auto tensor_hash = std::as_const(tensor).get_hash_();
+
+        std::cout << scalar_hash << std::endl;
+        std::cout << matrix_hash << std::endl;
+        std::cout << tensor_hash << std::endl;
+    }
+
     // -------------------------------------------------------------------------
     // -- Protected methods
     // -------------------------------------------------------------------------

--- a/tests/cxx/unit_tests/tensorwrapper/buffer/detail_/eigen_tensor.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/buffer/detail_/eigen_tensor.cpp
@@ -40,20 +40,20 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
     vector.set_elem({1}, 2.0);
 
     pimpl_type<TestType, 2> matrix(shape_type{2, 2});
-    matrix.get_elem({0, 0}) = 1.0;
-    matrix.get_elem({0, 1}) = 2.0;
-    matrix.get_elem({1, 0}) = 3.0;
-    matrix.get_elem({1, 1}) = 4.0;
+    matrix.set_elem({0, 0}, 1.0);
+    matrix.set_elem({0, 1}, 2.0);
+    matrix.set_elem({1, 0}, 3.0);
+    matrix.set_elem({1, 1}, 4.0);
 
     pimpl_type<TestType, 3> tensor(shape_type{2, 2, 2});
-    tensor.get_elem({0, 0, 0}) = 1.0;
-    tensor.get_elem({0, 0, 1}) = 2.0;
-    tensor.get_elem({0, 1, 0}) = 3.0;
-    tensor.get_elem({0, 1, 1}) = 4.0;
-    tensor.get_elem({1, 0, 0}) = 5.0;
-    tensor.get_elem({1, 0, 1}) = 6.0;
-    tensor.get_elem({1, 1, 0}) = 7.0;
-    tensor.get_elem({1, 1, 1}) = 8.0;
+    tensor.set_elem({0, 0, 0}, 1.0);
+    tensor.set_elem({0, 0, 1}, 2.0);
+    tensor.set_elem({0, 1, 0}, 3.0);
+    tensor.set_elem({0, 1, 1}, 4.0);
+    tensor.set_elem({1, 0, 0}, 5.0);
+    tensor.set_elem({1, 0, 1}, 6.0);
+    tensor.set_elem({1, 1, 0}, 7.0);
+    tensor.set_elem({1, 1, 1}, 8.0);
 
     // -------------------------------------------------------------------------
     // -- Public methods
@@ -149,27 +149,6 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
         REQUIRE(tensor.extent(2) == 2);
     }
 
-    SECTION("data_() const") {
-        REQUIRE(*std::as_const(scalar).data() == TestType{1.0});
-
-        REQUIRE(*std::as_const(vector).data() == TestType{1.0});
-        REQUIRE(*(std::as_const(vector).data() + 1) == TestType{2.0});
-
-        REQUIRE(*std::as_const(matrix).data() == TestType{1.0});
-        REQUIRE(*(std::as_const(matrix).data() + 1) == TestType{2.0});
-        REQUIRE(*(std::as_const(matrix).data() + 2) == TestType{3.0});
-        REQUIRE(*(std::as_const(matrix).data() + 3) == TestType{4.0});
-
-        REQUIRE(*std::as_const(tensor).data() == TestType{1.0});
-        REQUIRE(*(std::as_const(tensor).data() + 1) == TestType{2.0});
-        REQUIRE(*(std::as_const(tensor).data() + 2) == TestType{3.0});
-        REQUIRE(*(std::as_const(tensor).data() + 3) == TestType{4.0});
-        REQUIRE(*(std::as_const(tensor).data() + 4) == TestType{5.0});
-        REQUIRE(*(std::as_const(tensor).data() + 5) == TestType{6.0});
-        REQUIRE(*(std::as_const(tensor).data() + 6) == TestType{7.0});
-        REQUIRE(*(std::as_const(tensor).data() + 7) == TestType{8.0});
-    }
-
     SECTION("get_mutable_data_()") {
         SECTION("accessing") {
             REQUIRE(*scalar.get_mutable_data() == TestType{1.0});
@@ -209,25 +188,36 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
         }
     }
 
-    SECTION("get_elem_()") {
-        REQUIRE(scalar.get_elem({}) == TestType{1.0});
+    SECTION("get_immutable_data_() const") {
+        REQUIRE(*std::as_const(scalar).get_immutable_data() == TestType{1.0});
 
-        REQUIRE(vector.get_elem({0}) == TestType{1.0});
-        REQUIRE(vector.get_elem({1}) == TestType{2.0});
+        REQUIRE(*std::as_const(vector).get_immutable_data() == TestType{1.0});
+        REQUIRE(*(std::as_const(vector).get_immutable_data() + 1) ==
+                TestType{2.0});
 
-        REQUIRE(matrix.get_elem({0, 0}) == TestType{1.0});
-        REQUIRE(matrix.get_elem({0, 1}) == TestType{2.0});
-        REQUIRE(matrix.get_elem({1, 0}) == TestType{3.0});
-        REQUIRE(matrix.get_elem({1, 1}) == TestType{4.0});
+        REQUIRE(*std::as_const(matrix).get_immutable_data() == TestType{1.0});
+        REQUIRE(*(std::as_const(matrix).get_immutable_data() + 1) ==
+                TestType{2.0});
+        REQUIRE(*(std::as_const(matrix).get_immutable_data() + 2) ==
+                TestType{3.0});
+        REQUIRE(*(std::as_const(matrix).get_immutable_data() + 3) ==
+                TestType{4.0});
 
-        REQUIRE(tensor.get_elem({0, 0, 0}) == TestType{1.0});
-        REQUIRE(tensor.get_elem({0, 0, 1}) == TestType{2.0});
-        REQUIRE(tensor.get_elem({0, 1, 0}) == TestType{3.0});
-        REQUIRE(tensor.get_elem({0, 1, 1}) == TestType{4.0});
-        REQUIRE(tensor.get_elem({1, 0, 0}) == TestType{5.0});
-        REQUIRE(tensor.get_elem({1, 0, 1}) == TestType{6.0});
-        REQUIRE(tensor.get_elem({1, 1, 0}) == TestType{7.0});
-        REQUIRE(tensor.get_elem({1, 1, 1}) == TestType{8.0});
+        REQUIRE(*std::as_const(tensor).get_immutable_data() == TestType{1.0});
+        REQUIRE(*(std::as_const(tensor).get_immutable_data() + 1) ==
+                TestType{2.0});
+        REQUIRE(*(std::as_const(tensor).get_immutable_data() + 2) ==
+                TestType{3.0});
+        REQUIRE(*(std::as_const(tensor).get_immutable_data() + 3) ==
+                TestType{4.0});
+        REQUIRE(*(std::as_const(tensor).get_immutable_data() + 4) ==
+                TestType{5.0});
+        REQUIRE(*(std::as_const(tensor).get_immutable_data() + 5) ==
+                TestType{6.0});
+        REQUIRE(*(std::as_const(tensor).get_immutable_data() + 6) ==
+                TestType{7.0});
+        REQUIRE(*(std::as_const(tensor).get_immutable_data() + 7) ==
+                TestType{8.0});
     }
 
     SECTION("get_elem_() const") {
@@ -260,34 +250,47 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
         REQUIRE(vector.get_elem({1}) == TestType{2.0});
     }
 
-    SECTION("get_data_at_() const") {
-        REQUIRE(std::as_const(scalar).get_data_at(0) == TestType{1.0});
+    SECTION("get_data() const") {
+        REQUIRE(std::as_const(scalar).get_data(0) == TestType{1.0});
 
-        REQUIRE(std::as_const(vector).get_data_at(0) == TestType{1.0});
-        REQUIRE(std::as_const(vector).get_data_at(1) == TestType{2.0});
+        REQUIRE(std::as_const(vector).get_data(0) == TestType{1.0});
+        REQUIRE(std::as_const(vector).get_data(1) == TestType{2.0});
 
-        REQUIRE(std::as_const(matrix).get_data_at(0) == TestType{1.0});
-        REQUIRE(std::as_const(matrix).get_data_at(1) == TestType{2.0});
-        REQUIRE(std::as_const(matrix).get_data_at(2) == TestType{3.0});
-        REQUIRE(std::as_const(matrix).get_data_at(3) == TestType{4.0});
+        REQUIRE(std::as_const(matrix).get_data(0) == TestType{1.0});
+        REQUIRE(std::as_const(matrix).get_data(1) == TestType{2.0});
+        REQUIRE(std::as_const(matrix).get_data(2) == TestType{3.0});
+        REQUIRE(std::as_const(matrix).get_data(3) == TestType{4.0});
 
-        REQUIRE(std::as_const(tensor).get_data_at(0) == TestType{1.0});
-        REQUIRE(std::as_const(tensor).get_data_at(1) == TestType{2.0});
-        REQUIRE(std::as_const(tensor).get_data_at(2) == TestType{3.0});
-        REQUIRE(std::as_const(tensor).get_data_at(3) == TestType{4.0});
-        REQUIRE(std::as_const(tensor).get_data_at(4) == TestType{5.0});
-        REQUIRE(std::as_const(tensor).get_data_at(5) == TestType{6.0});
-        REQUIRE(std::as_const(tensor).get_data_at(6) == TestType{7.0});
-        REQUIRE(std::as_const(tensor).get_data_at(7) == TestType{8.0});
+        REQUIRE(std::as_const(tensor).get_data(0) == TestType{1.0});
+        REQUIRE(std::as_const(tensor).get_data(1) == TestType{2.0});
+        REQUIRE(std::as_const(tensor).get_data(2) == TestType{3.0});
+        REQUIRE(std::as_const(tensor).get_data(3) == TestType{4.0});
+        REQUIRE(std::as_const(tensor).get_data(4) == TestType{5.0});
+        REQUIRE(std::as_const(tensor).get_data(5) == TestType{6.0});
+        REQUIRE(std::as_const(tensor).get_data(6) == TestType{7.0});
+        REQUIRE(std::as_const(tensor).get_data(7) == TestType{8.0});
     }
 
-    SECTION("set_data_at_()") {
-        scalar.set_data_at(0, TestType{2.0});
-        REQUIRE(scalar.get_data_at(0) == TestType{2.0});
+    SECTION("set_data_()") {
+        scalar.set_data(0, TestType{2.0});
+        REQUIRE(scalar.get_data(0) == TestType{2.0});
 
-        vector.set_data_at(0, TestType{2.0});
-        REQUIRE(vector.get_data_at(0) == TestType{2.0});
-        REQUIRE(vector.get_data_at(1) == TestType{2.0});
+        vector.set_data(0, TestType{2.0});
+        REQUIRE(vector.get_data(0) == TestType{2.0});
+        REQUIRE(vector.get_data(1) == TestType{2.0});
+    }
+
+    SECTION("fill_()") {
+        vector.fill(TestType{42.0});
+        REQUIRE(vector.get_data(0) == TestType(42.0));
+        REQUIRE(vector.get_data(1) == TestType(42.0));
+    }
+
+    SECTION("copy_()") {
+        auto data = std::vector<TestType>(2, TestType(42.0));
+        vector.copy(data);
+        REQUIRE(vector.get_data(0) == TestType(42.0));
+        REQUIRE(vector.get_data(1) == TestType(42.0));
     }
 
     SECTION("are_equal_") {
@@ -339,14 +342,14 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.addition_assignment(o, l, r, tensor, tensor);
 
             pimpl_type<TestType, 3> corr(shape_type{2, 2, 2});
-            corr.get_elem({0, 0, 0}) = 2.0;
-            corr.get_elem({0, 0, 1}) = 4.0;
-            corr.get_elem({0, 1, 0}) = 6.0;
-            corr.get_elem({0, 1, 1}) = 8.0;
-            corr.get_elem({1, 0, 0}) = 10.0;
-            corr.get_elem({1, 0, 1}) = 12.0;
-            corr.get_elem({1, 1, 0}) = 14.0;
-            corr.get_elem({1, 1, 1}) = 16.0;
+            corr.set_elem({0, 0, 0}, 2.0);
+            corr.set_elem({0, 0, 1}, 4.0);
+            corr.set_elem({0, 1, 0}, 6.0);
+            corr.set_elem({0, 1, 1}, 8.0);
+            corr.set_elem({1, 0, 0}, 10.0);
+            corr.set_elem({1, 0, 1}, 12.0);
+            corr.set_elem({1, 1, 0}, 14.0);
+            corr.set_elem({1, 1, 1}, 16.0);
             REQUIRE(output == corr);
         }
 
@@ -359,14 +362,14 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.addition_assignment(o, l, r, tensor, tensor);
 
             pimpl_type<TestType, 3> corr(shape_type{2, 2, 2});
-            corr.get_elem({0, 0, 0}) = 2.0;
-            corr.get_elem({0, 0, 1}) = 7.0;
-            corr.get_elem({0, 1, 0}) = 6.0;
-            corr.get_elem({0, 1, 1}) = 11.0;
-            corr.get_elem({1, 0, 0}) = 7.0;
-            corr.get_elem({1, 0, 1}) = 12.0;
-            corr.get_elem({1, 1, 0}) = 11.0;
-            corr.get_elem({1, 1, 1}) = 16.0;
+            corr.set_elem({0, 0, 0}, 2.0);
+            corr.set_elem({0, 0, 1}, 7.0);
+            corr.set_elem({0, 1, 0}, 6.0);
+            corr.set_elem({0, 1, 1}, 11.0);
+            corr.set_elem({1, 0, 0}, 7.0);
+            corr.set_elem({1, 0, 1}, 12.0);
+            corr.set_elem({1, 1, 0}, 11.0);
+            corr.set_elem({1, 1, 1}, 16.0);
             REQUIRE(output == corr);
         }
 
@@ -379,14 +382,14 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.addition_assignment(o, l, r, tensor, tensor);
 
             pimpl_type<TestType, 3> corr(shape_type{2, 2, 2});
-            corr.get_elem({0, 0, 0}) = 2.0;
-            corr.get_elem({0, 0, 1}) = 7.0;
-            corr.get_elem({0, 1, 0}) = 6.0;
-            corr.get_elem({0, 1, 1}) = 11.0;
-            corr.get_elem({1, 0, 0}) = 7.0;
-            corr.get_elem({1, 0, 1}) = 12.0;
-            corr.get_elem({1, 1, 0}) = 11.0;
-            corr.get_elem({1, 1, 1}) = 16.0;
+            corr.set_elem({0, 0, 0}, 2.0);
+            corr.set_elem({0, 0, 1}, 7.0);
+            corr.set_elem({0, 1, 0}, 6.0);
+            corr.set_elem({0, 1, 1}, 11.0);
+            corr.set_elem({1, 0, 0}, 7.0);
+            corr.set_elem({1, 0, 1}, 12.0);
+            corr.set_elem({1, 1, 0}, 11.0);
+            corr.set_elem({1, 1, 1}, 16.0);
             REQUIRE(output == corr);
         }
 
@@ -399,14 +402,14 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.addition_assignment(o, l, r, tensor, tensor);
 
             pimpl_type<TestType, 3> corr(shape_type{2, 2, 2});
-            corr.get_elem({0, 0, 0}) = 2.0;
-            corr.get_elem({0, 0, 1}) = 8.0;
-            corr.get_elem({0, 1, 0}) = 8.0;
-            corr.get_elem({0, 1, 1}) = 14.0;
-            corr.get_elem({1, 0, 0}) = 4.0;
-            corr.get_elem({1, 0, 1}) = 10.0;
-            corr.get_elem({1, 1, 0}) = 10.0;
-            corr.get_elem({1, 1, 1}) = 16.0;
+            corr.set_elem({0, 0, 0}, 2.0);
+            corr.set_elem({0, 0, 1}, 8.0);
+            corr.set_elem({0, 1, 0}, 8.0);
+            corr.set_elem({0, 1, 1}, 14.0);
+            corr.set_elem({1, 0, 0}, 4.0);
+            corr.set_elem({1, 0, 1}, 10.0);
+            corr.set_elem({1, 1, 0}, 10.0);
+            corr.set_elem({1, 1, 1}, 16.0);
             REQUIRE(output == corr);
         }
     }
@@ -431,14 +434,14 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.subtraction_assignment(o, l, r, tensor, tensor);
 
             pimpl_type<TestType, 3> corr(shape_type{2, 2, 2});
-            corr.get_elem({0, 0, 0}) = 0.0;
-            corr.get_elem({0, 0, 1}) = 0.0;
-            corr.get_elem({0, 1, 0}) = 0.0;
-            corr.get_elem({0, 1, 1}) = 0.0;
-            corr.get_elem({1, 0, 0}) = 0.0;
-            corr.get_elem({1, 0, 1}) = 0.0;
-            corr.get_elem({1, 1, 0}) = 0.0;
-            corr.get_elem({1, 1, 1}) = 0.0;
+            corr.set_elem({0, 0, 0}, 0.0);
+            corr.set_elem({0, 0, 1}, 0.0);
+            corr.set_elem({0, 1, 0}, 0.0);
+            corr.set_elem({0, 1, 1}, 0.0);
+            corr.set_elem({1, 0, 0}, 0.0);
+            corr.set_elem({1, 0, 1}, 0.0);
+            corr.set_elem({1, 1, 0}, 0.0);
+            corr.set_elem({1, 1, 1}, 0.0);
             REQUIRE(output == corr);
         }
 
@@ -451,14 +454,14 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.subtraction_assignment(o, l, r, tensor, tensor);
 
             pimpl_type<TestType, 3> corr(shape_type{2, 2, 2});
-            corr.get_elem({0, 0, 0}) = 0.0;
-            corr.get_elem({0, 0, 1}) = 3.0;
-            corr.get_elem({0, 1, 0}) = 0.0;
-            corr.get_elem({0, 1, 1}) = 3.0;
-            corr.get_elem({1, 0, 0}) = -3.0;
-            corr.get_elem({1, 0, 1}) = 0.0;
-            corr.get_elem({1, 1, 0}) = -3.0;
-            corr.get_elem({1, 1, 1}) = 0.0;
+            corr.set_elem({0, 0, 0}, 0.0);
+            corr.set_elem({0, 0, 1}, 3.0);
+            corr.set_elem({0, 1, 0}, 0.0);
+            corr.set_elem({0, 1, 1}, 3.0);
+            corr.set_elem({1, 0, 0}, -3.0);
+            corr.set_elem({1, 0, 1}, 0.0);
+            corr.set_elem({1, 1, 0}, -3.0);
+            corr.set_elem({1, 1, 1}, 0.0);
             REQUIRE(output == corr);
         }
 
@@ -471,14 +474,14 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.subtraction_assignment(o, l, r, tensor, tensor);
 
             pimpl_type<TestType, 3> corr(shape_type{2, 2, 2});
-            corr.get_elem({0, 0, 0}) = 0.0;
-            corr.get_elem({0, 0, 1}) = -3.0;
-            corr.get_elem({0, 1, 0}) = 0.0;
-            corr.get_elem({0, 1, 1}) = -3.0;
-            corr.get_elem({1, 0, 0}) = 3.0;
-            corr.get_elem({1, 0, 1}) = 0.0;
-            corr.get_elem({1, 1, 0}) = 3.0;
-            corr.get_elem({1, 1, 1}) = 0.0;
+            corr.set_elem({0, 0, 0}, 0.0);
+            corr.set_elem({0, 0, 1}, -3.0);
+            corr.set_elem({0, 1, 0}, 0.0);
+            corr.set_elem({0, 1, 1}, -3.0);
+            corr.set_elem({1, 0, 0}, 3.0);
+            corr.set_elem({1, 0, 1}, 0.0);
+            corr.set_elem({1, 1, 0}, 3.0);
+            corr.set_elem({1, 1, 1}, 0.0);
             REQUIRE(output == corr);
         }
 
@@ -491,14 +494,14 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.subtraction_assignment(o, l, r, tensor, tensor);
 
             pimpl_type<TestType, 3> corr(shape_type{2, 2, 2});
-            corr.get_elem({0, 0, 0}) = 0.0;
-            corr.get_elem({0, 0, 1}) = 2.0;
-            corr.get_elem({0, 1, 0}) = -2.0;
-            corr.get_elem({0, 1, 1}) = 0.0;
-            corr.get_elem({1, 0, 0}) = 0.0;
-            corr.get_elem({1, 0, 1}) = 2.0;
-            corr.get_elem({1, 1, 0}) = -2.0;
-            corr.get_elem({1, 1, 1}) = 0.0;
+            corr.set_elem({0, 0, 0}, 0.0);
+            corr.set_elem({0, 0, 1}, 2.0);
+            corr.set_elem({0, 1, 0}, -2.0);
+            corr.set_elem({0, 1, 1}, 0.0);
+            corr.set_elem({1, 0, 0}, 0.0);
+            corr.set_elem({1, 0, 1}, 2.0);
+            corr.set_elem({1, 1, 0}, -2.0);
+            corr.set_elem({1, 1, 1}, 0.0);
             REQUIRE(output == corr);
         }
     }
@@ -523,14 +526,14 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.hadamard_assignment(o, l, r, tensor, tensor);
 
             pimpl_type<TestType, 3> corr(shape_type{2, 2, 2});
-            corr.get_elem({0, 0, 0}) = 1.0;
-            corr.get_elem({0, 0, 1}) = 4.0;
-            corr.get_elem({0, 1, 0}) = 9.0;
-            corr.get_elem({0, 1, 1}) = 16.0;
-            corr.get_elem({1, 0, 0}) = 25.0;
-            corr.get_elem({1, 0, 1}) = 36.0;
-            corr.get_elem({1, 1, 0}) = 49.0;
-            corr.get_elem({1, 1, 1}) = 64.0;
+            corr.set_elem({0, 0, 0}, 1.0);
+            corr.set_elem({0, 0, 1}, 4.0);
+            corr.set_elem({0, 1, 0}, 9.0);
+            corr.set_elem({0, 1, 1}, 16.0);
+            corr.set_elem({1, 0, 0}, 25.0);
+            corr.set_elem({1, 0, 1}, 36.0);
+            corr.set_elem({1, 1, 0}, 49.0);
+            corr.set_elem({1, 1, 1}, 64.0);
             REQUIRE(output == corr);
         }
 
@@ -543,14 +546,14 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.hadamard_assignment(o, l, r, tensor, tensor);
 
             pimpl_type<TestType, 3> corr(shape_type{2, 2, 2});
-            corr.get_elem({0, 0, 0}) = 1.0;
-            corr.get_elem({0, 0, 1}) = 10.0;
-            corr.get_elem({0, 1, 0}) = 9.0;
-            corr.get_elem({0, 1, 1}) = 28.0;
-            corr.get_elem({1, 0, 0}) = 10.0;
-            corr.get_elem({1, 0, 1}) = 36.0;
-            corr.get_elem({1, 1, 0}) = 28.0;
-            corr.get_elem({1, 1, 1}) = 64.0;
+            corr.set_elem({0, 0, 0}, 1.0);
+            corr.set_elem({0, 0, 1}, 10.0);
+            corr.set_elem({0, 1, 0}, 9.0);
+            corr.set_elem({0, 1, 1}, 28.0);
+            corr.set_elem({1, 0, 0}, 10.0);
+            corr.set_elem({1, 0, 1}, 36.0);
+            corr.set_elem({1, 1, 0}, 28.0);
+            corr.set_elem({1, 1, 1}, 64.0);
             REQUIRE(output == corr);
         }
 
@@ -563,14 +566,14 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.hadamard_assignment(o, l, r, tensor, tensor);
 
             pimpl_type<TestType, 3> corr(shape_type{2, 2, 2});
-            corr.get_elem({0, 0, 0}) = 1.0;
-            corr.get_elem({0, 0, 1}) = 10.0;
-            corr.get_elem({0, 1, 0}) = 9.0;
-            corr.get_elem({0, 1, 1}) = 28.0;
-            corr.get_elem({1, 0, 0}) = 10.0;
-            corr.get_elem({1, 0, 1}) = 36.0;
-            corr.get_elem({1, 1, 0}) = 28.0;
-            corr.get_elem({1, 1, 1}) = 64.0;
+            corr.set_elem({0, 0, 0}, 1.0);
+            corr.set_elem({0, 0, 1}, 10.0);
+            corr.set_elem({0, 1, 0}, 9.0);
+            corr.set_elem({0, 1, 1}, 28.0);
+            corr.set_elem({1, 0, 0}, 10.0);
+            corr.set_elem({1, 0, 1}, 36.0);
+            corr.set_elem({1, 1, 0}, 28.0);
+            corr.set_elem({1, 1, 1}, 64.0);
             REQUIRE(output == corr);
         }
 
@@ -583,14 +586,14 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.hadamard_assignment(o, l, r, tensor, tensor);
 
             pimpl_type<TestType, 3> corr(shape_type{2, 2, 2});
-            corr.get_elem({0, 0, 0}) = 1.0;
-            corr.get_elem({0, 0, 1}) = 15.0;
-            corr.get_elem({0, 1, 0}) = 15.0;
-            corr.get_elem({0, 1, 1}) = 49.0;
-            corr.get_elem({1, 0, 0}) = 4.0;
-            corr.get_elem({1, 0, 1}) = 24.0;
-            corr.get_elem({1, 1, 0}) = 24.0;
-            corr.get_elem({1, 1, 1}) = 64.0;
+            corr.set_elem({0, 0, 0}, 1.0);
+            corr.set_elem({0, 0, 1}, 15.0);
+            corr.set_elem({0, 1, 0}, 15.0);
+            corr.set_elem({0, 1, 1}, 49.0);
+            corr.set_elem({1, 0, 0}, 4.0);
+            corr.set_elem({1, 0, 1}, 24.0);
+            corr.set_elem({1, 1, 0}, 24.0);
+            corr.set_elem({1, 1, 1}, 64.0);
             REQUIRE(output == corr);
         }
     }
@@ -634,10 +637,10 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.contraction_assignment(o, l, r, oshape, tensor, tensor);
 
             pimpl_type<TestType, 2> corr(oshape);
-            corr.get_elem({0, 0}) = 50.0;
-            corr.get_elem({0, 1}) = 60.0;
-            corr.get_elem({1, 0}) = 114.0;
-            corr.get_elem({1, 1}) = 140.0;
+            corr.set_elem({0, 0}, 50.0);
+            corr.set_elem({0, 1}, 60.0);
+            corr.set_elem({1, 0}, 114.0);
+            corr.set_elem({1, 1}, 140.0);
             REQUIRE(output == corr);
         }
 
@@ -651,10 +654,10 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.contraction_assignment(o, l, r, oshape, tensor, tensor);
 
             pimpl_type<TestType, 2> corr(oshape);
-            corr.get_elem({0, 0}) = 44.0;
-            corr.get_elem({0, 1}) = 64.0;
-            corr.get_elem({1, 0}) = 100.0;
-            corr.get_elem({1, 1}) = 152.0;
+            corr.set_elem({0, 0}, 44.0);
+            corr.set_elem({0, 1}, 64.0);
+            corr.set_elem({1, 0}, 100.0);
+            corr.set_elem({1, 1}, 152.0);
             REQUIRE(output == corr);
         }
 
@@ -668,10 +671,10 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.contraction_assignment(o, l, r, oshape, tensor, tensor);
 
             pimpl_type<TestType, 2> corr(oshape);
-            corr.get_elem({0, 0}) = 44.0;
-            corr.get_elem({0, 1}) = 100.0;
-            corr.get_elem({1, 0}) = 64.0;
-            corr.get_elem({1, 1}) = 152.0;
+            corr.set_elem({0, 0}, 44.0);
+            corr.set_elem({0, 1}, 100.0);
+            corr.set_elem({1, 0}, 64.0);
+            corr.set_elem({1, 1}, 152.0);
             REQUIRE(output == corr);
         }
 
@@ -685,22 +688,22 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.contraction_assignment(o, l, r, oshape, tensor, tensor);
 
             pimpl_type<TestType, 4> corr(oshape);
-            corr.get_elem({0, 0, 0, 0}) = 10.0;
-            corr.get_elem({0, 0, 0, 1}) = 14.0;
-            corr.get_elem({0, 0, 1, 0}) = 26.0;
-            corr.get_elem({0, 0, 1, 1}) = 30.0;
-            corr.get_elem({0, 1, 0, 0}) = 14.0;
-            corr.get_elem({0, 1, 0, 1}) = 20.0;
-            corr.get_elem({0, 1, 1, 0}) = 38.0;
-            corr.get_elem({0, 1, 1, 1}) = 44.0;
-            corr.get_elem({1, 0, 0, 0}) = 26.0;
-            corr.get_elem({1, 0, 0, 1}) = 38.0;
-            corr.get_elem({1, 0, 1, 0}) = 74.0;
-            corr.get_elem({1, 0, 1, 1}) = 86.0;
-            corr.get_elem({1, 1, 0, 0}) = 30.0;
-            corr.get_elem({1, 1, 0, 1}) = 44.0;
-            corr.get_elem({1, 1, 1, 0}) = 86.0;
-            corr.get_elem({1, 1, 1, 1}) = 100.0;
+            corr.set_elem({0, 0, 0, 0}, 10.0);
+            corr.set_elem({0, 0, 0, 1}, 14.0);
+            corr.set_elem({0, 0, 1, 0}, 26.0);
+            corr.set_elem({0, 0, 1, 1}, 30.0);
+            corr.set_elem({0, 1, 0, 0}, 14.0);
+            corr.set_elem({0, 1, 0, 1}, 20.0);
+            corr.set_elem({0, 1, 1, 0}, 38.0);
+            corr.set_elem({0, 1, 1, 1}, 44.0);
+            corr.set_elem({1, 0, 0, 0}, 26.0);
+            corr.set_elem({1, 0, 0, 1}, 38.0);
+            corr.set_elem({1, 0, 1, 0}, 74.0);
+            corr.set_elem({1, 0, 1, 1}, 86.0);
+            corr.set_elem({1, 1, 0, 0}, 30.0);
+            corr.set_elem({1, 1, 0, 1}, 44.0);
+            corr.set_elem({1, 1, 1, 0}, 86.0);
+            corr.set_elem({1, 1, 1, 1}, 100.0);
 
             REQUIRE(output == corr);
         }
@@ -715,14 +718,14 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.contraction_assignment(o, l, r, oshape, matrix, tensor);
 
             pimpl_type<TestType, 3> corr(oshape);
-            corr.get_elem({0, 0, 0}) = 11.0;
-            corr.get_elem({0, 0, 1}) = 14.0;
-            corr.get_elem({0, 1, 0}) = 17.0;
-            corr.get_elem({0, 1, 1}) = 20.0;
-            corr.get_elem({1, 0, 0}) = 23.0;
-            corr.get_elem({1, 0, 1}) = 30.0;
-            corr.get_elem({1, 1, 0}) = 37.0;
-            corr.get_elem({1, 1, 1}) = 44.0;
+            corr.set_elem({0, 0, 0}, 11.0);
+            corr.set_elem({0, 0, 1}, 14.0);
+            corr.set_elem({0, 1, 0}, 17.0);
+            corr.set_elem({0, 1, 1}, 20.0);
+            corr.set_elem({1, 0, 0}, 23.0);
+            corr.set_elem({1, 0, 1}, 30.0);
+            corr.set_elem({1, 1, 0}, 37.0);
+            corr.set_elem({1, 1, 1}, 44.0);
 
             REQUIRE(corr == output);
         }
@@ -745,10 +748,10 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.permute_assignment(o, i, matrix);
 
             pimpl_type<TestType, 2> corr(shape_type{2, 2});
-            corr.get_elem({0, 0}) = 1.0;
-            corr.get_elem({0, 1}) = 3.0;
-            corr.get_elem({1, 0}) = 2.0;
-            corr.get_elem({1, 1}) = 4.0;
+            corr.set_elem({0, 0}, 1.0);
+            corr.set_elem({0, 1}, 3.0);
+            corr.set_elem({1, 0}, 2.0);
+            corr.set_elem({1, 1}, 4.0);
             REQUIRE(output == corr);
         }
     }
@@ -762,10 +765,10 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.scalar_multiplication(o, i, 2.0, matrix);
 
             pimpl_type<TestType, 2> corr(shape_type{2, 2});
-            corr.get_elem({0, 0}) = 2.0;
-            corr.get_elem({0, 1}) = 4.0;
-            corr.get_elem({1, 0}) = 6.0;
-            corr.get_elem({1, 1}) = 8.0;
+            corr.set_elem({0, 0}, 2.0);
+            corr.set_elem({0, 1}, 4.0);
+            corr.set_elem({1, 0}, 6.0);
+            corr.set_elem({1, 1}, 8.0);
 
             REQUIRE(output == corr);
         }
@@ -776,10 +779,10 @@ TEMPLATE_LIST_TEST_CASE("EigenTensor", "", types::floating_point_types) {
             output.scalar_multiplication(o, i, 2.0, matrix);
 
             pimpl_type<TestType, 2> corr(shape_type{2, 2});
-            corr.get_elem({0, 0}) = 2.0;
-            corr.get_elem({0, 1}) = 6.0;
-            corr.get_elem({1, 0}) = 4.0;
-            corr.get_elem({1, 1}) = 8.0;
+            corr.set_elem({0, 0}, 2.0);
+            corr.set_elem({0, 1}, 6.0);
+            corr.set_elem({1, 0}, 4.0);
+            corr.set_elem({1, 1}, 8.0);
             REQUIRE(output == corr);
         }
     }

--- a/tests/cxx/unit_tests/tensorwrapper/buffer/detail_/hash_utilities.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/buffer/detail_/hash_utilities.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../../testing/testing.hpp"
+#include <tensorwrapper/buffer/detail_/hash_utilities.hpp>
+
+using namespace tensorwrapper;
+using namespace testing;
+
+using buffer::detail_::hash_utilities::hash_input;
+using hash_type = buffer::detail_::hash_utilities::hash_type;
+
+// Make sure we know if this changes for some reason
+TEST_CASE("hash_type") { REQUIRE(std::is_same_v<hash_type, std::size_t>); }
+
+// Checking dispatching
+TEMPLATE_LIST_TEST_CASE("hash_input", "", types::floating_point_types) {
+    using value_type = TestType;
+    hash_type seed{0};
+    if constexpr(types::is_uncertain_v<TestType>) {
+        value_type value(1.0, 1.0);
+        hash_input(seed, value);
+        hash_type corr{0};
+        boost::hash_combine(corr, value.mean());
+        boost::hash_combine(corr, value.sd());
+        for(const auto& [dep, deriv] : value.deps()) {
+            boost::hash_combine(corr, dep);
+            boost::hash_combine(corr, deriv);
+        }
+        REQUIRE(seed == corr);
+    } else {
+        value_type value(1.0);
+        hash_input(seed, value);
+        hash_type corr{0};
+        boost::hash_combine(corr, value_type{1.0});
+        REQUIRE(seed == corr);
+    }
+}

--- a/tests/cxx/unit_tests/tensorwrapper/buffer/eigen.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/buffer/eigen.cpp
@@ -185,10 +185,10 @@ TEMPLATE_LIST_TEST_CASE("Eigen", "", types::floating_point_types) {
             REQUIRE(output.are_equal(*corr));
         }
 
-        SECTION("data()") {
-            REQUIRE(defaulted.data() == nullptr);
-            REQUIRE(*eigen_scalar.data() == TestType{10.0});
-            REQUIRE(*eigen_matrix.data() == TestType{10.0});
+        SECTION("get_mutable_data()") {
+            REQUIRE(defaulted.get_mutable_data() == nullptr);
+            REQUIRE(*eigen_scalar.get_mutable_data() == TestType{10.0});
+            REQUIRE(*eigen_matrix.get_mutable_data() == TestType{10.0});
         }
 
         SECTION("data() const") {

--- a/tests/cxx/unit_tests/tensorwrapper/buffer/eigen.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/buffer/eigen.cpp
@@ -28,30 +28,30 @@ TEMPLATE_LIST_TEST_CASE("Eigen", "", types::floating_point_types) {
 
     auto pscalar       = testing::eigen_scalar<TestType>();
     auto& eigen_scalar = static_cast<buffer_type&>(*pscalar);
-    eigen_scalar.at()  = 10.0;
+    eigen_scalar.set_elem({}, 10.0);
 
     auto pvector       = testing::eigen_vector<TestType>(2);
     auto& eigen_vector = static_cast<buffer_type&>(*pvector);
-    eigen_vector.at(0) = 10.0;
-    eigen_vector.at(1) = 20.0;
+    eigen_vector.set_elem({0}, 10.0);
+    eigen_vector.set_elem({1}, 20.0);
 
-    auto pmatrix          = testing::eigen_matrix<TestType>(2, 3);
-    auto& eigen_matrix    = static_cast<buffer_type&>(*pmatrix);
-    eigen_matrix.at(0, 0) = 10.0;
-    eigen_matrix.at(0, 1) = 20.0;
-    eigen_matrix.at(0, 2) = 30.0;
-    eigen_matrix.at(1, 0) = 40.0;
-    eigen_matrix.at(1, 1) = 50.0;
-    eigen_matrix.at(1, 2) = 60.0;
+    auto pmatrix       = testing::eigen_matrix<TestType>(2, 3);
+    auto& eigen_matrix = static_cast<buffer_type&>(*pmatrix);
+    eigen_matrix.set_elem({0, 0}, 10.0);
+    eigen_matrix.set_elem({0, 1}, 20.0);
+    eigen_matrix.set_elem({0, 2}, 30.0);
+    eigen_matrix.set_elem({1, 0}, 40.0);
+    eigen_matrix.set_elem({1, 1}, 50.0);
+    eigen_matrix.set_elem({1, 2}, 60.0);
 
-    auto ptensor             = testing::eigen_tensor3<TestType>(1, 2, 3);
-    auto& eigen_tensor       = static_cast<buffer_type&>(*ptensor);
-    eigen_tensor.at(0, 0, 0) = 10.0;
-    eigen_tensor.at(0, 0, 1) = 20.0;
-    eigen_tensor.at(0, 0, 2) = 30.0;
-    eigen_tensor.at(0, 1, 0) = 40.0;
-    eigen_tensor.at(0, 1, 1) = 50.0;
-    eigen_tensor.at(0, 1, 2) = 60.0;
+    auto ptensor       = testing::eigen_tensor3<TestType>(1, 2, 3);
+    auto& eigen_tensor = static_cast<buffer_type&>(*ptensor);
+    eigen_tensor.set_elem({0, 0, 0}, 10.0);
+    eigen_tensor.set_elem({0, 0, 1}, 20.0);
+    eigen_tensor.set_elem({0, 0, 2}, 30.0);
+    eigen_tensor.set_elem({0, 1, 0}, 40.0);
+    eigen_tensor.set_elem({0, 1, 1}, 50.0);
+    eigen_tensor.set_elem({0, 1, 2}, 60.0);
 
     auto scalar_layout = scalar_physical();
     auto vector_layout = vector_physical(2);
@@ -61,7 +61,9 @@ TEMPLATE_LIST_TEST_CASE("Eigen", "", types::floating_point_types) {
     buffer_type defaulted;
 
     SECTION("ctors, assignment") {
-        SECTION("default ctor") { REQUIRE(defaulted.data() == nullptr); }
+        SECTION("default ctor") {
+            REQUIRE(defaulted.get_immutable_data() == nullptr);
+        }
 
         SECTION("value ctor") {
             REQUIRE(eigen_scalar.layout().are_equal(scalar_layout));
@@ -85,7 +87,7 @@ TEMPLATE_LIST_TEST_CASE("Eigen", "", types::floating_point_types) {
         // Checking Layout/Allocator falls to base class tests
         auto pscalar2       = testing::eigen_scalar<TestType>();
         auto& eigen_scalar2 = static_cast<buffer_type&>(*pscalar2);
-        eigen_scalar2.at()  = 10.0;
+        eigen_scalar2.set_elem({}, 10.0);
 
         // Defaulted != scalar
         REQUIRE_FALSE(defaulted == eigen_scalar);
@@ -94,7 +96,7 @@ TEMPLATE_LIST_TEST_CASE("Eigen", "", types::floating_point_types) {
         REQUIRE(eigen_scalar == eigen_scalar2);
 
         SECTION("Different buffer value") {
-            eigen_scalar2.at() = 2.0;
+            eigen_scalar2.set_elem({}, 2.0);
             REQUIRE_FALSE(eigen_scalar == eigen_scalar2);
         }
     }
@@ -102,10 +104,10 @@ TEMPLATE_LIST_TEST_CASE("Eigen", "", types::floating_point_types) {
     SECTION("operator!=") {
         auto pscalar2       = testing::eigen_scalar<TestType>();
         auto& eigen_scalar2 = static_cast<buffer_type&>(*pscalar2);
-        eigen_scalar2.at()  = 10.0;
+        eigen_scalar2.set_elem({}, 10.0);
 
         REQUIRE_FALSE(eigen_scalar != eigen_scalar2);
-        eigen_scalar2.at() = 2.0;
+        eigen_scalar2.set_elem({}, 2.0);
         REQUIRE(eigen_scalar != eigen_scalar2);
     }
 
@@ -126,9 +128,9 @@ TEMPLATE_LIST_TEST_CASE("Eigen", "", types::floating_point_types) {
             auto vi = eigen_vector("i");
             output.addition_assignment("i", vi, vi);
 
-            auto corr   = testing::eigen_vector<TestType>(2);
-            corr->at(0) = 20.0;
-            corr->at(1) = 40.0;
+            auto corr = testing::eigen_vector<TestType>(2);
+            corr->set_elem({0}, 20.0);
+            corr->set_elem({1}, 40.0);
 
             REQUIRE(output.are_equal(*corr));
         }
@@ -138,9 +140,9 @@ TEMPLATE_LIST_TEST_CASE("Eigen", "", types::floating_point_types) {
             auto vi = eigen_vector("i");
             output.subtraction_assignment("i", vi, vi);
 
-            auto corr   = testing::eigen_vector<TestType>(2);
-            corr->at(0) = 0.0;
-            corr->at(1) = 0.0;
+            auto corr = testing::eigen_vector<TestType>(2);
+            corr->set_elem({0}, 0.0);
+            corr->set_elem({1}, 0.0);
 
             REQUIRE(output.are_equal(*corr));
         }
@@ -150,9 +152,9 @@ TEMPLATE_LIST_TEST_CASE("Eigen", "", types::floating_point_types) {
             auto vi = eigen_vector("i");
             output.multiplication_assignment("i", vi, vi);
 
-            auto corr   = testing::eigen_vector<TestType>(2);
-            corr->at(0) = 100.0;
-            corr->at(1) = 400.0;
+            auto corr = testing::eigen_vector<TestType>(2);
+            corr->set_elem({0}, 100.0);
+            corr->set_elem({1}, 400.0);
 
             REQUIRE(output.are_equal(*corr));
         }
@@ -162,13 +164,13 @@ TEMPLATE_LIST_TEST_CASE("Eigen", "", types::floating_point_types) {
             auto mij = eigen_matrix("i,j");
             output.permute_assignment("j,i", mij);
 
-            auto corr      = testing::eigen_matrix<TestType>(3, 2);
-            corr->at(0, 0) = 10.0;
-            corr->at(0, 1) = 40.0;
-            corr->at(1, 0) = 20.0;
-            corr->at(1, 1) = 50.0;
-            corr->at(2, 0) = 30.0;
-            corr->at(2, 1) = 60.0;
+            auto corr = testing::eigen_matrix<TestType>(3, 2);
+            corr->set_elem({0, 0}, 10.0);
+            corr->set_elem({0, 1}, 40.0);
+            corr->set_elem({1, 0}, 20.0);
+            corr->set_elem({1, 1}, 50.0);
+            corr->set_elem({2, 0}, 30.0);
+            corr->set_elem({2, 1}, 60.0);
 
             REQUIRE(output.are_equal(*corr));
         }
@@ -178,35 +180,62 @@ TEMPLATE_LIST_TEST_CASE("Eigen", "", types::floating_point_types) {
             auto vi = eigen_vector("i");
             output.scalar_multiplication("i", 2.0, vi);
 
-            auto corr   = testing::eigen_vector<TestType>(2);
-            corr->at(0) = 20.0;
-            corr->at(1) = 40.0;
+            auto corr = testing::eigen_vector<TestType>(2);
+            corr->set_elem({0}, 20.0);
+            corr->set_elem({1}, 40.0);
 
             REQUIRE(output.are_equal(*corr));
         }
 
-        SECTION("get_mutable_data()") {
+        SECTION("get_mutable_data_()") {
             REQUIRE(defaulted.get_mutable_data() == nullptr);
             REQUIRE(*eigen_scalar.get_mutable_data() == TestType{10.0});
             REQUIRE(*eigen_matrix.get_mutable_data() == TestType{10.0});
         }
 
-        SECTION("data() const") {
-            REQUIRE(std::as_const(defaulted).data() == nullptr);
-            REQUIRE(*std::as_const(eigen_scalar).data() == TestType{10.0});
-            REQUIRE(*std::as_const(eigen_matrix).data() == TestType{10.0});
-        }
-
-        SECTION("get_elem_()") {
-            REQUIRE(eigen_scalar.at() == TestType{10.0});
-            REQUIRE(eigen_vector.at(0) == TestType{10.0});
-            REQUIRE(eigen_matrix.at(0, 0) == TestType{10.0});
+        SECTION("get_immutable_data_() const") {
+            REQUIRE(std::as_const(defaulted).get_immutable_data() == nullptr);
+            REQUIRE(*std::as_const(eigen_scalar).get_immutable_data() ==
+                    TestType{10.0});
+            REQUIRE(*std::as_const(eigen_matrix).get_immutable_data() ==
+                    TestType{10.0});
         }
 
         SECTION("get_elem_() const") {
-            REQUIRE(std::as_const(eigen_scalar).at() == TestType{10.0});
-            REQUIRE(std::as_const(eigen_vector).at(0) == TestType{10.0});
-            REQUIRE(std::as_const(eigen_matrix).at(0, 0) == TestType{10.0});
+            TestType corr{10.0};
+            REQUIRE(std::as_const(eigen_scalar).get_elem({}) == corr);
+            REQUIRE(std::as_const(eigen_vector).get_elem({0}) == corr);
+            REQUIRE(std::as_const(eigen_matrix).get_elem({0, 0}) == corr);
+        }
+
+        SECTION("set_elem_()") {
+            eigen_vector.set_elem({0}, TestType{42.0});
+            REQUIRE(eigen_vector.get_elem({0}) == TestType{42.0});
+        }
+
+        SECTION("get_data_() const") {
+            TestType corr{10.0};
+            REQUIRE(std::as_const(eigen_scalar).get_data(0) == corr);
+            REQUIRE(std::as_const(eigen_vector).get_data(0) == corr);
+            REQUIRE(std::as_const(eigen_matrix).get_data(0) == corr);
+        }
+
+        SECTION("set_data_()") {
+            eigen_vector.set_data(0, TestType{42.0});
+            REQUIRE(eigen_vector.get_data(0) == TestType{42.0});
+        }
+
+        SECTION("fill_()") {
+            eigen_vector.fill(TestType{42.0});
+            REQUIRE(eigen_vector.get_data(0) == TestType(42.0));
+            REQUIRE(eigen_vector.get_data(1) == TestType(42.0));
+        }
+
+        SECTION("copy_()") {
+            auto data = std::vector<TestType>(2, TestType(42.0));
+            eigen_vector.copy(data);
+            REQUIRE(eigen_vector.get_data(0) == TestType(42.0));
+            REQUIRE(eigen_vector.get_data(1) == TestType(42.0));
         }
     }
 }

--- a/tests/cxx/unit_tests/tensorwrapper/dsl/dsl.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/dsl/dsl.cpp
@@ -94,9 +94,9 @@ TEST_CASE("DSLr : buffer::Eigen") {
     auto& scalar2 = *pscalar2;
     auto& corr    = *pcorr;
 
-    scalar0.at() = 1.0;
-    scalar1.at() = 2.0;
-    scalar2.at() = 3.0;
+    scalar0.set_data(0, 1.0);
+    scalar1.set_data(0, 2.0);
+    scalar2.set_data(0, 3.0);
 
     SECTION("assignment") {
         SECTION("scalar") {

--- a/tests/cxx/unit_tests/tensorwrapper/dsl/pairwise_parser.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/dsl/pairwise_parser.cpp
@@ -134,9 +134,9 @@ TEST_CASE("PairwiseParser : buffer::Eigen") {
     auto& scalar2 = *pscalar2;
     auto& corr    = *pcorr;
 
-    scalar0.at() = 1.0;
-    scalar1.at() = 2.0;
-    scalar2.at() = 3.0;
+    scalar0.set_data(0, 1.0);
+    scalar1.set_data(0, 2.0);
+    scalar2.set_data(0, 3.0);
 
     dsl::PairwiseParser p;
 

--- a/tests/cxx/unit_tests/tensorwrapper/operations/approximately_equal.cpp
+++ b/tests/cxx/unit_tests/tensorwrapper/operations/approximately_equal.cpp
@@ -31,17 +31,17 @@ using namespace operations;
 
 TEMPLATE_LIST_TEST_CASE("approximately_equal", "",
                         types::floating_point_types) {
-    auto pscalar   = testing::eigen_scalar<TestType>();
-    pscalar->at()  = 42.0;
-    auto pvector   = testing::eigen_vector<TestType>(2);
-    pvector->at(0) = 1.23;
-    pvector->at(1) = 2.34;
+    auto pscalar = testing::eigen_scalar<TestType>();
+    pscalar->set_data(0, 42.0);
+    auto pvector = testing::eigen_vector<TestType>(2);
+    pvector->set_data(0, 1.23);
+    pvector->set_data(1, 2.34);
 
-    auto pscalar2   = testing::eigen_scalar<TestType>();
-    pscalar2->at()  = 42.0;
-    auto pvector2   = testing::eigen_vector<TestType>(2);
-    pvector2->at(0) = 1.23;
-    pvector2->at(1) = 2.34;
+    auto pscalar2 = testing::eigen_scalar<TestType>();
+    pscalar2->set_data(0, 42.0);
+    auto pvector2 = testing::eigen_vector<TestType>(2);
+    pvector2->set_data(0, 1.23);
+    pvector2->set_data(1, 2.34);
 
     shape::Smooth s0{};
     shape::Smooth s1{2};
@@ -65,9 +65,9 @@ TEMPLATE_LIST_TEST_CASE("approximately_equal", "",
     }
 
     SECTION("Differ by more than default tolerance") {
-        double value    = 1e-1;
-        pscalar2->at()  = 42.0 + value;
-        pvector2->at(0) = 1.23 + value;
+        double value = 1e-1;
+        pscalar2->set_data(0, 42.0 + value);
+        pvector2->set_data(0, 1.23 + value);
         Tensor scalar2(s0, std::move(pscalar2));
         Tensor vector2(s1, std::move(pvector2));
         REQUIRE_FALSE(approximately_equal(scalar, scalar2));
@@ -77,9 +77,9 @@ TEMPLATE_LIST_TEST_CASE("approximately_equal", "",
     }
 
     SECTION("Differ by less than default tolerance") {
-        double value    = 1e-17;
-        pscalar2->at()  = 42.0 + value;
-        pvector2->at(0) = 1.23 + value;
+        double value = 1e-17;
+        pscalar2->set_data(0, 42.0 + value);
+        pvector2->set_data(0, 1.23 + value);
         Tensor scalar2(s0, std::move(pscalar2));
         Tensor vector2(s1, std::move(pvector2));
         REQUIRE(approximately_equal(scalar, scalar2));
@@ -89,9 +89,9 @@ TEMPLATE_LIST_TEST_CASE("approximately_equal", "",
     }
 
     SECTION("Differ by more than provided tolerance") {
-        float value     = 1e-1;
-        pscalar2->at()  = 43.0;
-        pvector2->at(0) = 2.23;
+        float value = 1e-1;
+        pscalar2->set_data(0, 43.0);
+        pvector2->set_data(0, 2.23);
         Tensor scalar2(s0, std::move(pscalar2));
         Tensor vector2(s1, std::move(pvector2));
         REQUIRE_FALSE(approximately_equal(scalar, scalar2, value));
@@ -101,9 +101,9 @@ TEMPLATE_LIST_TEST_CASE("approximately_equal", "",
     }
 
     SECTION("Differ by less than provided tolerance") {
-        double value    = 1e-10;
-        pscalar2->at()  = 42.0 + value;
-        pvector2->at(0) = 1.23 + value;
+        double value = 1e-10;
+        pscalar2->set_data(0, 42.0 + value);
+        pvector2->set_data(0, 1.23 + value);
         Tensor scalar2(s0, std::move(pscalar2));
         Tensor vector2(s1, std::move(pvector2));
         REQUIRE(approximately_equal(scalar, scalar2, 1e-1));

--- a/tests/cxx/unit_tests/tensorwrapper/testing/eigen_buffers.hpp
+++ b/tests/cxx/unit_tests/tensorwrapper/testing/eigen_buffers.hpp
@@ -43,7 +43,7 @@ auto eigen_vector(std::size_t n = 5) {
     layout::Physical l(shape::Smooth{n});
     auto alloc  = make_allocator<FloatType>();
     auto buffer = alloc.allocate(l);
-    for(std::size_t i = 0; i < n; ++i) buffer->at(i) = i;
+    for(std::size_t i = 0; i < n; ++i) buffer->set_elem({i}, i);
     return buffer;
 }
 
@@ -54,7 +54,7 @@ auto eigen_matrix(std::size_t n = 2, std::size_t m = 2) {
     auto buffer    = alloc.allocate(l);
     double counter = 1.0;
     for(decltype(n) i = 0; i < n; ++i)
-        for(decltype(m) j = 0; j < m; ++j) buffer->at(i, j) = counter++;
+        for(decltype(m) j = 0; j < m; ++j) buffer->set_elem({i, j}, counter++);
     return buffer;
 }
 
@@ -66,7 +66,8 @@ auto eigen_tensor3(std::size_t n = 2, std::size_t m = 2, std::size_t l = 2) {
     double counter = 1.0;
     for(decltype(n) i = 0; i < n; ++i)
         for(decltype(m) j = 0; j < m; ++j)
-            for(decltype(l) k = 0; k < l; ++k) buffer->at(i, j, k) = counter++;
+            for(decltype(l) k = 0; k < l; ++k)
+                buffer->set_elem({i, j, k}, counter++);
     return buffer;
 }
 
@@ -82,7 +83,7 @@ auto eigen_tensor4(std::array<std::size_t, 4> extents = {2, 2, 2, 2}) {
         for(i[1] = 0; i[1] < extents[1]; ++i[1])
             for(i[2] = 0; i[2] < extents[2]; ++i[2])
                 for(i[3] = 0; i[3] < extents[3]; ++i[3])
-                    buffer->at(i[0], i[1], i[2], i[3]) = counter++;
+                    buffer->set_elem({i[0], i[1], i[2], i[3]}, counter++);
     return buffer;
 }
 

--- a/tests/cxx/unit_tests/tensorwrapper/testing/inputs.hpp
+++ b/tests/cxx/unit_tests/tensorwrapper/testing/inputs.hpp
@@ -62,7 +62,7 @@ inline auto smooth_matrix_() {
 inline auto smooth_matrix_input() { return smooth_matrix_<double>(); }
 
 inline auto smooth_symmetric_matrix_input() {
-    auto pmatrix      = eigen_matrix<double>(3, 3);
+    auto pmatrix = eigen_matrix<double>(3, 3);
     pmatrix->set_elem({0, 0}, 1.0);
     pmatrix->set_elem({0, 1}, 2.0);
     pmatrix->set_elem({0, 2}, 3.0);

--- a/tests/cxx/unit_tests/tensorwrapper/testing/inputs.hpp
+++ b/tests/cxx/unit_tests/tensorwrapper/testing/inputs.hpp
@@ -63,15 +63,15 @@ inline auto smooth_matrix_input() { return smooth_matrix_<double>(); }
 
 inline auto smooth_symmetric_matrix_input() {
     auto pmatrix      = eigen_matrix<double>(3, 3);
-    pmatrix->at(0, 0) = 1.0;
-    pmatrix->at(0, 1) = 2.0;
-    pmatrix->at(0, 2) = 3.0;
-    pmatrix->at(1, 0) = 2.0;
-    pmatrix->at(1, 1) = 4.0;
-    pmatrix->at(1, 2) = 5.0;
-    pmatrix->at(2, 0) = 3.0;
-    pmatrix->at(2, 1) = 5.0;
-    pmatrix->at(2, 2) = 6.0;
+    pmatrix->set_elem({0, 0}, 1.0);
+    pmatrix->set_elem({0, 1}, 2.0);
+    pmatrix->set_elem({0, 2}, 3.0);
+    pmatrix->set_elem({1, 0}, 2.0);
+    pmatrix->set_elem({1, 1}, 4.0);
+    pmatrix->set_elem({1, 2}, 5.0);
+    pmatrix->set_elem({2, 0}, 3.0);
+    pmatrix->set_elem({2, 1}, 5.0);
+    pmatrix->set_elem({2, 2}, 6.0);
     shape::Smooth shape{3, 3};
     symmetry::Permutation p01{0, 1};
     symmetry::Group g(p01);


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
This PR changes the API used to interact with the `Contiguous` and `Eigen` buffers, moving towards explicit getters and setters for accessing data. `get_elem`/`set_elem` uses coordinate indices, while `get_data`/`set_data` uses ordinal indices (overloading wasn't used for these because the index types make the signatures ambiguous). A read-only pointer to the underlying data is accessible with `get_immutable_data`, while a read/write pointer is available with `get_mutable_data`.

The `get_mutable_data` function should be used with care because of the second part of this PR, which is switching to a hash-based equality check for buffers. Having mutable pointers to the underlying data around means it is unfeasible to track changes within the tensor, so using `get_mutable_data` turns off any attempt to store the hash of the current state and requires recalculation each time equality is checked. Otherwise, the hash will only be updated when a non-const method is called (or if it's the first time it's being checked).
