### PR TITLE
Removes stale code for installing config.hpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,6 @@ docs/source/api
 _build/
 Debug/
 Release/
-
+install/
 # Users commonly store their specific CMake settings in a toolchain file
 toolchain.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,3 @@ if("${BUILD_TESTING}")
 endif()
 
 cmaize_add_package(${PROJECT_NAME} NAMESPACE nwx::)
-install(
-    FILES ${CMAKE_BINARY_DIR}/config.hpp
-    DESTINATION include/${PROJECT_NAME}
-)


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Undocumented issue for the install procedure. When installing, the install is unable to find "config.hpp", which fails the install.

**Description**
Removes the install statement in CMakeLists.txt for config.hpp

**TODOs**
Should be r2g after reviw
