### PR TITLE
Add proper name to find Eigen installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ find_package(Boost REQUIRED)
 
 cmaize_find_or_build_dependency(
     eigen
+    NAME Eigen3
     URL https://www.gitlab.com/libeigen/eigen
     VERSION 2e76277bd049f7bec36b0f908c69734a42c5234f
     BUILD_TARGET eigen


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
CMaize defaults to using the provided identifier for `cmaize_find*_dependency` calls when calling `find_package()`. The name provided for Eigen here is `eigen`, but the installation is actually under directories named `eigen3`. The provided name has to be fairly exact for CMake to find the installed package. This PR fixes the name so that an existing Eigen installation is able to be found and used.

The Eigen installation references the `eigen3` subdirectories starting [here](https://gitlab.com/libeigen/eigen/-/blob/master/CMakeLists.txt?ref_type=heads#L150). The config search mode used in `find_package()` in CMaize is case insensitive, so I used `Eigen3` to match the project name for Eigen ([here](https://gitlab.com/libeigen/eigen/-/blob/master/CMakeLists.txt?ref_type=heads#L36)).

**TODOs**
- [ ] Does this work on Windows? I've only tested on Linux.
