### PR TITLE
Adds Nightly GHA Workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,32 @@
+# Copyright 2025 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Pull Request Workflow
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # Every day at 06:00 UTC (00:00 CST)
+
+jobs:
+  test_library:
+    uses: NWChemEx/.github/.github/workflows/test_nwx_library.yaml@master
+    with:
+      compilers: '["gcc-14", "clang-18"]'
+
+  test_library_with_sigma:
+    uses: NWChemEx/.github/.github/workflows/test_nwx_library.yaml@master
+    with:
+      compilers: '["gcc-14", "clang-18"]'
+      repo_toolchain: ".github/enable_sigma.cmake"

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@
   ~ limitations under the License.
 -->
 
-[![Actions](https://github.com/NWChemEx/TensorWrapper/workflows/C_C++_CI/badge.svg)](https://github.com/NWChemEx/TensorWrapper)
-
-[![Codecov](https://codecov.io/github/NWChemEx/TensorWrapper/branch/master/graphs/sunburst.svg?token=MwvRQD5eUW)](https://codecov.io/github/NWChemEx/TensorWrapper/branch/master)
-
 # TensorWrapper
+
+[![Nightly Workflow](https://github.com/NWChemEx/TensorWrapper/actions/workflows/nightly.yaml/badge.svg)](https://github.com/NWChemEx/TensorWrapper/actions/workflows/nightly.yaml)


### PR DESCRIPTION
Description
Like the title says, this PR adds a nightly workflow to test the build and run the unit tests.
