### PR TITLE
Libc++ Patch

### DIFF
--- a/include/tensorwrapper/types/floating_point.hpp
+++ b/include/tensorwrapper/types/floating_point.hpp
@@ -92,10 +92,10 @@ T pow(T value, double pow) {
 #define TW_APPLY_FLOATING_POINT_TYPES(MACRO_IN) \
     MACRO_IN(float);                            \
     MACRO_IN(double);                           \
-    MACRO_IN(types::ufloat);                    \
-    MACRO_IN(types::udouble);                   \
-    MACRO_IN(types::ifloat);                    \
-    MACRO_IN(types::idouble);
+    MACRO_IN(tensorwrapper::types::ufloat);     \
+    MACRO_IN(tensorwrapper::types::udouble);    \
+    MACRO_IN(tensorwrapper::types::ifloat);     \
+    MACRO_IN(tensorwrapper::types::idouble);
 } // namespace tensorwrapper::types
 
 WTF_REGISTER_FP_TYPE(tensorwrapper::types::ufloat);
@@ -147,3 +147,11 @@ T pow(T value, double pow) {
 
 } // namespace tensorwrapper::types
 #endif
+
+#define DECLARE_WTF_CONTIGUOUS(TYPE)                                   \
+    extern template class wtf::buffer::detail_::ContiguousModel<TYPE>; \
+    extern template class wtf::buffer::detail_::ContiguousViewModel<TYPE>;
+
+TW_APPLY_FLOATING_POINT_TYPES(DECLARE_WTF_CONTIGUOUS);
+
+#undef DECLARE_WTF_CONTIGUOUS

--- a/src/python/tensor/export_tensor.cpp
+++ b/src/python/tensor/export_tensor.cpp
@@ -17,7 +17,9 @@
 #include "export_tensor.hpp"
 #include <pybind11/numpy.h>
 #include <pybind11/operators.h>
-#include <tensorwrapper/tensorwrapper.hpp>
+#include <tensorwrapper/buffer/contiguous.hpp>
+#include <tensorwrapper/concepts/floating_point.hpp>
+#include <tensorwrapper/tensor/tensor.hpp>
 
 namespace tensorwrapper {
 namespace {

--- a/src/tensorwrapper/types/floating_point.cpp
+++ b/src/tensorwrapper/types/floating_point.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NWChemEx-Project
+ * Copyright 2026 NWChemEx-Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-#include "tensor/export_tensor.hpp"
-#include <pybind11/pybind11.h>
+#include <tensorwrapper/types/floating_point.hpp>
 
-namespace tensorwrapper {
+#define DEFINE_WTF_CONTIGUOUS(TYPE)                             \
+    template class wtf::buffer::detail_::ContiguousModel<TYPE>; \
+    template class wtf::buffer::detail_::ContiguousViewModel<TYPE>;
 
-PYBIND11_MODULE(tensorwrapper, m) {
-    m.doc() = "PyTensorWrapper : Python bindings for TensorWrapper";
+TW_APPLY_FLOATING_POINT_TYPES(DEFINE_WTF_CONTIGUOUS);
 
-    export_tensor(m);
-}
-
-} // namespace tensorwrapper
+#undef DEFINE_WTF_CONTIGUOUS

--- a/tests/python/unit_tests/tensor/test_tensor.py
+++ b/tests/python/unit_tests/tensor/test_tensor.py
@@ -32,12 +32,9 @@ class TestTensor(unittest.TestCase):
         self.assertEqual(self.matrix_from_cpp.rank(), 2)
 
     def test_equality(self):
-        pass
-
-        # XXX: In the CI, this breaks with Clang and a non-sensical stack trace
-        # self.assertTrue(self.scalar == self.scalar_from_cpp)
-        # self.assertTrue(self.vector == self.vector_from_cpp)
-        # self.assertTrue(self.matrix == self.matrix_from_cpp)
+        self.assertTrue(self.scalar == self.scalar_from_cpp)
+        self.assertTrue(self.vector == self.vector_from_cpp)
+        self.assertTrue(self.matrix == self.matrix_from_cpp)
 
     def test_inequality(self):
         self.assertTrue(self.defaulted != self.scalar)


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
Resolves the issue with the LLVM Clang/Python tests that required commenting out the equality checks,